### PR TITLE
feat(email): define array of popular email domains

### DIFF
--- a/email/popularDomains.json
+++ b/email/popularDomains.json
@@ -1,0 +1,5 @@
+[
+  "gmail.com", "hotmail.com", "yahoo.com", "mail.ru", "outlook.com", "aol.com", "qq.com",
+  "web.de", "yandex.ru", "gmx.de", "live.com", "comcast.net", "t-online.de", "hotmail.fr",
+  "msn.com", "yahoo.fr", "orange.fr", "163.com", "icloud.com", "hotmail.co.uk"
+]

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 
 module.exports = {
+  email: {
+    popularDomains: require('./email/popularDomains')
+  },
   l10n: {
     localizeTimestamp: require('./l10n/localizeTimestamp'),
     supportedLanguages: require('./l10n/supportedLanguages')

--- a/test/email/popularDomains.js
+++ b/test/email/popularDomains.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+
+describe('email/popularDomains:', () => {
+  let popularDomains;
+
+  before(() => {
+    popularDomains = require('../../email/popularDomains');
+  });
+
+  it('returns an array of 20 domains', () => {
+    assert.isArray(popularDomains);
+    assert.lengthOf(popularDomains, 20);
+  });
+
+  it('includes some well-known domains', () => {
+    assert.isAtLeast(popularDomains.indexOf('gmail.com'), 0);
+    assert.isAtLeast(popularDomains.indexOf('hotmail.com'), 0);
+    assert.isAtLeast(popularDomains.indexOf('yahoo.com'), 0);
+  });
+});

--- a/test/l10n/localizeTimestamp.js
+++ b/test/l10n/localizeTimestamp.js
@@ -6,7 +6,7 @@
 
 const { assert } = require('chai');
 
-describe('localizeTimestamp:', () => {
+describe('l10n/localizeTimestamp:', () => {
   let localizeTimestamp;
 
   before(() => {

--- a/test/l10n/supportedLanguages.js
+++ b/test/l10n/supportedLanguages.js
@@ -6,7 +6,7 @@
 
 const { assert } = require('chai');
 
-describe('supportedLanguages:', () => {
+describe('l10n/supportedLanguages:', () => {
   let supportedLanguages;
 
   before(() => {


### PR DESCRIPTION
Related to mozilla/fxa-content-server#6014.

There are duplicate definitions for this array in the auth and content servers. As @vbudhram pointed out in https://github.com/mozilla/fxa-content-server/pull/6012#discussion_r178104726, that's silly.

@mozilla/fxa-devs r?