### PR TITLE
feat(scope): Implement shareable code for checking OAuth scopes.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,5 @@ env:
 
 rules:
   handle-callback-err: off
-  semi: off
+  semi: [2, "always"]
   quotes: off

--- a/README.md
+++ b/README.md
@@ -6,6 +6,87 @@
 
 `supportedLanguages.json` is the shared list of all supported locales across FxA
 
+
+### oauth
+
+`oauth.scopes` provides shared logic for validating and checking OAuth scopes.
+
+Detailed documentation on the details of FxA OAuth scope values
+is available from the [fxa-oauth-server](https://github.com/mozilla/fxa-oauth-server/tree/master/docs/scopes.md).
+This library provides some convenient APIs for working with them
+according to the rules described there.
+
+Given a string containing scopes,
+you can parse it into a `ScopeSet` object
+from either a raw space-delimited string:
+
+```
+let s1 = oauth.scopes.fromString('profile:write basket');
+```
+
+Or directly from a url-encoded string:
+
+```
+let s2 = oauth.scopes.fromURLEncodedString('profile%3Aemail+profile%3Adisplay_name+clients');
+```
+
+Once you have a `ScopeSet` object,
+you can check whether it
+is sufficient to wholly imply another set:
+
+```
+  s1.contains('profile:email:write');          // true, implied by 'profile:write'
+  s2.contains('profile:email:write');          // false
+  s1.contains('profile:email:write clients');  // false, 'clients' is not in `s1`
+```
+
+Or whether it has
+any scope values in common
+with another set:
+
+```
+  s1.intersects('profile:email:write clients'); // true, 'profile:email:write' is common
+  s2.intersects(s1);                            // true, 'profile:email' is common
+  s2.intersects('clients:write basket');        // false, no members in common
+```
+
+You can filter it down
+to only the scope values
+implied by another scope:
+
+```
+  let s3 = oauth.scope.fromString('profile:email clients:abcd'));
+  s3.filtered(s1); // 'profile:email'
+  s3.filtered(s2); // 'profile:email clients:abcd'
+```
+
+Or you can find out
+what values in the set
+are *not* implied by another scope:
+
+```
+  s3.difference(s1); // 'clients:abcd'
+  s3.difference(s2); // the empty set
+  s2.difference(s3); // 'profile:display_name clients'
+```
+
+You can also combine multiple sets of scopes,
+either by generating the union as a new set:
+
+```
+  s1.union(s2); // 'profile:write basket clients'
+```
+
+Or by building up the new set in place:
+
+```
+  let allScopes = scopes.fromArray([]);
+  allScopes.add(s1);  // now "profile:write basket"
+  allScopes.add(s2);  // now "profile:write basket clients"
+  allScopes.add(s3);  // now "profile:write basket clients"
+```
+
+
 ## Publishing new version
 
 Install the [np](https://github.com/sindresorhus/np) tool, run `np [new_version_here]`.

--- a/index.js
+++ b/index.js
@@ -9,5 +9,8 @@ module.exports = {
   l10n: {
     localizeTimestamp: require('./l10n/localizeTimestamp'),
     supportedLanguages: require('./l10n/supportedLanguages')
+  },
+  oauth: {
+    scopes: require('./oauth/scopes')
   }
 };

--- a/l10n/localizeTimestamp.js
+++ b/l10n/localizeTimestamp.js
@@ -68,6 +68,6 @@ module.exports = function (options) {
       // return a formatted `timeago` type string
       return lastAccessTime.fromNow();
     }
-  }
+  };
 
-}
+};

--- a/metrics/amplitude.js
+++ b/metrics/amplitude.js
@@ -46,7 +46,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.registration]: NOP,
   [GROUPS.settings]: mapDisconnectReason,
   [GROUPS.sms]: NOP
-}
+};
 
 function NOP () {}
 
@@ -166,7 +166,7 @@ module.exports = {
       if (mapping) {
         eventType = mapping.event;
         if (typeof eventType === 'function') {
-          eventType = eventType(eventCategory, eventTarget)
+          eventType = eventType(eventCategory, eventTarget);
           if (! eventType) {
             return;
           }
@@ -198,7 +198,7 @@ module.exports = {
           user_properties: mapUserProperties(eventGroup, eventCategory, data)
         });
       }
-    }
+    };
 
     function mapEventProperties (eventType, eventGroup, eventCategory, eventTarget, data) {
       const { serviceName, clientId } = getServiceNameAndClientId(data);
@@ -206,7 +206,7 @@ module.exports = {
       return Object.assign(pruneUnsetValues({
         service: serviceName,
         oauth_client_id: clientId
-      }), EVENT_PROPERTIES[eventGroup](eventType, eventCategory, eventTarget, data))
+      }), EVENT_PROPERTIES[eventGroup](eventType, eventCategory, eventTarget, data));
     }
 
     function getServiceNameAndClientId (data) {
@@ -215,14 +215,14 @@ module.exports = {
       const { service } = data;
       if (service && service !== 'content-server') {
         if (service === 'sync') {
-          serviceName = service
+          serviceName = service;
         } else {
-          serviceName = services[service] || 'undefined_oauth'
-          clientId = service
+          serviceName = services[service] || 'undefined_oauth';
+          clientId = service;
         }
       }
 
-      return { serviceName, clientId }
+      return { serviceName, clientId };
     }
 
     function mapUserProperties (eventGroup, eventCategory, data) {
@@ -276,7 +276,7 @@ function pruneUnsetValues (data) {
     if (value || value === false) {
       result[key] = value;
     }
-  })
+  });
 
   return result;
 }
@@ -312,7 +312,7 @@ function mapSyncDevices (data) {
 }
 
 function countDevices (devices, period) {
-  return devices.filter(device => device.lastAccessTime >= Date.now() - period).length
+  return devices.filter(device => device.lastAccessTime >= Date.now() - period).length;
 }
 
 function mapNewsletterState (eventCategory, data) {

--- a/oauth/scopes.js
+++ b/oauth/scopes.js
@@ -1,0 +1,612 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { URL } = require('url');
+
+// These character ranges are from the OAuth RFC,
+// https://tools.ietf.org/html/rfc6749#section-3.3
+const VALID_SCOPE_VALUE = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+
+const VALID_SHORT_NAME_VALUE = /^[a-zA-Z0-9_]+$/;
+const VALID_FRAGMENT_VALUE = /^#[a-zA-Z0-9_]+$/;
+
+
+/**
+ * A `ScopeSet` object represents a set of validated scope string values,
+ * against which we can perform various membership checks and set-like
+ * operations such as:
+ *
+ *  - Checking whether one set of scope values wholly or partly
+ *    contains another set.
+ *
+ *  - Filtering out scope values that are (or are not) implied
+ *    by another set.
+ *
+ *  - Aggregating values into a single set.
+ *
+ * A quick note on some terminology:
+ *
+ *  - A "scope" is a string value representing a particular capabilty
+ *    that can be granted to client applications.  Such strings can be
+ *    in one of two forms:
+ *
+ *     - a "short-name scope" such as "profile" or "profile:email"
+ *     - a "URL-format scope" such as "https://identity.mozilla.com/apps/sync"
+ *
+ *  - We say that a scope "implies" another scope if it represents
+ *    a strictly more general capability.  For example:
+ *
+ *     - the scope "profile" implies "profile:email" and "profile:avatar",
+ *       but does not imply "basket" or "profile:write".
+ *
+ *     - the scope "profile:write" implies "profile" and "profile:email:write",
+ *       but does not imply "basket" or "basket:write".
+ *
+ *     - the scope "https://identity.mozilla.com/apps/sync" implies
+ *       "https://identity.mozilla.com/apps/sync/bookmarks", but does not
+ *       imply "https://identity.mozilla.com/apps/lockbox".
+ *
+ *  - If a scope A implies scope B, then we say that B is a "sub-scope"
+ *    of A, and that A is an "implicant" of B.  Any scope value has a
+ *    finite number of implicants.
+ *
+ *  - We group individual scope values into sets represented by the
+ *    `ScopeSet` object.
+ *
+ * We expect that the `ScopeSet` class will be used to process user-provided
+ * data, so it's important that it provides efficient operations that do
+ * not open potential DoS vectors.  In particular, we need to ensure
+ * linear-time-or-better membership testing and merging of multiple `ScopeSet`
+ * instances.
+ *
+ * Performance is achieved by using a simple trick: for any given scope value,
+ * we can pre-compute a finite set of all possible implicants.  This allows us
+ * to implement "A implies B" as a simple string lookup for "A" in the set of
+ * implicants of "B".
+ *
+ * The tradeoff here is memory usage, as we have to store the full
+ * set of implicants for each scope value in the set.  We expect that this
+ * will not be too problematic in practice, because the size of this set is
+ * linear in the length of the scope value. A more memory-friendly approach
+ * could use a trie-like data structure to efficiently store all implicants
+ * with prefix compression, at the cost of significant code complexity.
+ *
+ */
+class ScopeSet {
+
+  constructor(scopes=[]) {
+    // To support efficient lookups, we store the set of scopes and
+    // their fully-expanded set of implicants in a bi-directional mapping.
+    //
+    // In one direction, we map each scope in this ScopeSet to its full set of
+    // implicants.  If the scope string `s` is in `this._scopesToImplicants`,
+    // then `s` is a member of this ScopeSet, and the corresponding value gives
+    // all possible scopes that might imply it.
+    this._scopesToImplicants = {};
+
+    // In the other direction, we map every implicant of a scope in this
+    // ScopeSet to the set of scopes that it implies.  If the scope string
+    // `s` is in `this._implicantsToScopes`, then `s` implies at least one
+    // of the scopes in this ScopeSet, and the corresponding value gives all
+    // of the scopes that it implies.
+    this._implicantsToScopes = {};
+
+    // Creating `ScopeSet` instances is then a simple matter of building
+    // up that bi-directional mapping, one scope value at a time.
+    for (const s of scopes) {
+      this._addScope(s, new Set(getImplicantValues(s)));
+    }
+  }
+
+  /*
+   * Check whether this `ScopeSet` contains the given scope.
+   *
+   */
+  _hasScope(scope) {
+    return (scope in this._scopesToImplicants);
+  }
+
+  /*
+   * Check whether this `ScopeSet` contains one of the given scopes.
+   *
+   */
+  _hasSomeScope(scopes) {
+    for (const scope of scopes) {
+      if (this._hasScope(scope)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*
+   * Check whether something in this `ScopeSet` is implied by
+   * the given scope.
+   *
+   */
+  _hasImplicant(scope) {
+    return (scope in this._implicantsToScopes);
+  }
+
+  /*
+   * Check whether something in this `ScopeSet` is implied by
+   * one of the given scopes.
+   *
+   */
+  _hasSomeImplicant(scopes) {
+    for (const scope of scopes) {
+      if (scope in this._implicantsToScopes) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*
+   * Iterate over the scopes in this `ScopeSet`, and their
+   * corresponding sets of implicants.
+   *
+   */
+  _iterScopes(cb) {
+    for (const scope in this._scopesToImplicants) {
+      cb(scope, this._scopesToImplicants[scope]);
+    }
+  }
+
+  /*
+   * Iterate over the implicants of this `ScopeSet`, and their
+   * corresponding sets of implied scopes.
+   *
+   */
+  _iterImplicants(cb) {
+    for (const implicant in this._implicantsToScopes) {
+      cb(implicant, this._implicantsToScopes[implicant]);
+    }
+  }
+
+  /*
+   * Iterate over the scopes in this `ScopeSet` that are implied by
+   * the given scope.
+   *
+   */
+  _iterImpliedScopes(implicant, cb) {
+    const impliedScopes = this._implicantsToScopes[implicant];
+    if (impliedScopes) {
+      for (const impliedScope of impliedScopes) {
+        cb(impliedScope);
+      }
+    }
+  }
+
+  /*
+   * Search through the scopes in this `ScopeSet` to see whether
+   * any matches the given predicate function.  The search terminates
+   * at the first successful match.
+   *
+   */
+  _searchScopes(cb) {
+    for (const scope in this._scopesToImplicants) {
+      if (cb(scope, this._scopesToImplicants[scope])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*
+   * Search through the implicants of this `ScopeSet` to see whether
+   * any matches the given predicate function.  The search terminates
+   * at the first successful match.
+   *
+   */
+  _searchImplicants(cb) {
+    for (const implicant in this._implicantsToScopes) {
+      if (cb(implicant, this._implicantsToScopes[implicant])) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*
+   * Add a scope to this `ScopeSet`.
+   * The new scope may imply some scopes that are already in
+   * the set, in which case the redundant scopes will be removed in
+   * order to keep memory usage down and simplify further handling.
+   *
+   */
+  _addScope(scope, implicants) {
+    // If the scope is already implied by something in this `ScopeSet`,
+    // then we can safely ignore it.
+    if (this._hasSomeScope(implicants)) {
+      return;
+    }
+    // If the new scope implies some scopes that are already in this
+    // `ScopeSet`, then those scopes are now redundant and can be removed.
+    this._iterImpliedScopes(scope, implied => {
+      this._removeScope(implied);
+    });
+    // Add it into the bi-directional mapping.
+    this._scopesToImplicants[scope] = implicants;
+    for (const implicant of implicants) {
+      if (! (implicant in this._implicantsToScopes)) {
+        this._implicantsToScopes[implicant] = new Set();
+      }
+      this._implicantsToScopes[implicant].add(scope);
+    }
+  }
+
+  /*
+   * Remove a scope from this `ScopeSet`.
+   *
+   * This must maintain the bi-directional mapping between
+   * scopes and their implicants.
+   *
+   */
+  _removeScope(scope) {
+    const implicants = this._scopesToImplicants[scope];
+    for (const implicant of implicants) {
+      const impliedScopes = this._implicantsToScopes[implicant];
+      impliedScopes.delete(scope);
+      if (impliedScopes.size === 0) {
+        delete this._implicantsToScopes[implicant];
+      }
+    }
+    delete this._scopesToImplicants[scope];
+  }
+
+  toString() {
+    return this.toJSON().join(' ');
+  }
+
+  toJSON() {
+    return this.getScopeValues();
+  }
+
+  /**
+   * Get the list of scope strings in this `ScopeSet`.
+   *
+   */
+  getScopeValues() {
+    return Object.keys(this._scopesToImplicants);
+  }
+
+  /**
+   * Get the list of all scope strings that imply a scope in this `ScopeSet`.
+   *
+   * This can be useful to reduce the operation of scope checking to
+   * a simple string lookup.
+   *
+   */
+  getImplicantValues() {
+    return Object.keys(this._implicantsToScopes);
+  }
+
+  /**
+   * Check whether this `ScopeSet` contains any scope values at all.
+   *
+   */
+  isEmpty() {
+    for (const _ in this._scopesToImplicants) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Add scope values from another `ScopeSet`.
+   *
+   * `A.add(B)` modifies `A` in-place to add the scope values from `B`,
+   * removing any redundant entries.
+   *
+   * Importantly, aggregating multiple `ScopeSet` instances into a single
+   * set by repeatedly calling this method is linear in the number of
+   * scope values being processed.  This means that it can be safely
+   * used to aggregate user-provided data without hiding any "accidentally
+   * quadratic" performance traps.
+   *
+   */
+  add(other) {
+    other = coerce(other)._iterScopes((scope, implicants) => {
+      this._addScope(scope, implicants);
+    });
+  }
+
+  /**
+   * Check whether one set of scopes wholly contains another.
+   *
+   * A set of scopes `A` contains another set `B` if every scope value
+   * in `B` is implied by some scope value in `A`.  In other words,
+   * `A` represents a strictly more general set of capabilities
+   * than `B`.
+   *
+   */
+  contains(other) {
+    return ! coerce(other)._searchScopes((scope, implicants) => {
+      return ! this._hasSomeScope(implicants);
+    });
+  }
+
+  /**
+   * Check whether one set of scopes intersects with another.
+   *
+   * A set of scopes `A` intersects another set `B` if there is some scope
+   * value in `B` that is implied by a scope value in `A`, or there is
+   * some scope value in `A` that is implied by a scope value in `B`.
+   *
+   */
+  intersects(other) {
+    other = coerce(other);
+    return other._searchImplicants(implicant => {
+      return this._hasScope(implicant);
+    }) || this._searchImplicants(implicant => {
+      return other._hasScope(implicant);
+    });
+  }
+
+  /**
+   * Find the subset of scopes from this `ScopeSet` that are implied
+   * by another set.
+   *
+   * `A.filtered(B)` returns the largest subset of scope values
+   * from `A` that are implied by some scope value in `B`.  It
+   * returns a new `ScopeSet` instance.
+   *
+   * It's useful to think of `A.filtered(B)` as checking a set
+   * of requested capabilities in `A` against a set of allowed
+   * capabilities in `B`.  The result will be the subset of the
+   * requested capabilities that are actually allowed.
+   *
+   * Note that it does *not* behave strictly like classical set
+   * intersection, in that there may exist a scope implied by
+   * both `A` and `B` which is not in `A.filtered(B)`.
+   * Consider for example:
+   *
+   *    A = 'profile:email:write'
+   *    B = 'profile'
+   *
+   *`A.filtered(B)` in this case will be empty, as 'profile' is a read-only
+   * scope that cannot imply any ':write' scopes.  There is a scope that
+   * is implied by both `A` and `B` ('profile:email') but since it is not
+   * directly a member of `A`, it will not appear in the result.
+   *
+   */
+  filtered(other) {
+    other = coerce(other);
+    const result = new ScopeSet();
+    this._iterScopes((scope, implicants) => {
+      if (other._hasSomeScope(implicants)) {
+        result._addScope(scope, implicants);
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Find the subset of scopes from this `ScopeSet` that are not implied
+   * by another set.
+   *
+   * `A.difference(B)` returns the largest subset of scope values
+   * from `A` that are *not* implied by a scope in `B`; these are
+   * precisely those scope values that would have been removed by
+   * `A.filtered(B)`. It returns a new `ScopeSet` object.
+   *
+   */
+  difference(other) {
+    other = coerce(other);
+    const result = new ScopeSet();
+    this._iterScopes((scope, implicants) => {
+      if (! other._hasSomeScope(implicants)) {
+        result._addScope(scope, implicants);
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Get the combined set of scope values implied by either this `ScopeSet`
+   * or another.
+   *
+   * `A.union(B)` returns the smallest set of scope values that are implied
+   * either `A` or `B` (or both).  It returns a new `ScopeSet` object.
+   *
+   */
+  union(other) {
+    other = coerce(other);
+    const result = new ScopeSet();
+    this._iterScopes((scope, implicants) => {
+      result._addScope(scope, implicants);
+    });
+    other._iterScopes((scope, implicants) => {
+      result._addScope(scope, implicants);
+    });
+    return result;
+  }
+
+}
+
+
+/**
+ * A little helper function for coercing different
+ * kinds of input data into a `ScopeSet` instance.
+ *
+ */
+function coerce(scopes) {
+  if (scopes instanceof ScopeSet) {
+    return scopes;
+  }
+  // If we receive a string, assume it's a single scope.
+  // We deliberately do not attempt to split the string on whitespace here,
+  // because we want to force callers to explicitly choose between
+  // exports.fromString() or exports.fromURLEncodedString depending on
+  // what encoding they expect to have received the string in.
+  if (typeof scopes === 'string') {
+    return new ScopeSet([scopes]);
+  }
+  return new ScopeSet(scopes);
+}
+
+
+/**
+ * An iterator yielding all implicants of the given scope value.
+ *
+ */
+function getImplicantValues(value) {
+  if (value.startsWith('https:')) {
+    return getImplicantValuesForURLScope(value);
+  } else {
+    return getImplicantValuesForShortScope(value);
+  }
+}
+
+
+/**
+ * Our "short-name scopes" are things like:
+ *
+ *   * "openid"
+ *   * "profile"
+ *   * "profile:write"
+ *   * "profile:display_name:write"
+ *
+ * The scope value is a colon-separated list of
+ * alphanumeric strings.  The special value "write"
+ * may appear as the last component to indicate write
+ * access, otherwise access is read-only.
+ *
+ * Implication is essentially the prefix relationship
+ * on the name components, with the additional rule
+ * only "write" scopes can imply other "write" scopes.
+ *
+ */
+function* getImplicantValuesForShortScope(value) {
+  if (! VALID_SCOPE_VALUE.test(value)) {
+    throw new Error('Invalid scope value: ' + value);
+  }
+  // Parse it into its colon-separated name components,
+  // and handle the special "write" flag if present.
+  let hasWrite = false;
+  const names = value.split(':');
+  names.forEach(name => {
+    if (! VALID_SHORT_NAME_VALUE.test(name)) {
+      throw new Error('Invalid scope value: ' + value);
+    }
+  });
+  if (names[names.length - 1] === 'write') {
+    hasWrite = true;
+    names.pop();
+    // Disallow "write" as a standalone scope.
+    if (names.length === 0) {
+      throw new Error('Invalid scope value: ' + value);
+    }
+  }
+  // All prefixes of the name component list will imply this scope.
+  // In addition, a read-only scope will be implied by the corresponding
+  // write sope, but not vice-versa.
+  while (names.length > 0) {
+    yield names.join(':') + ':write';
+    if (! hasWrite) {
+      yield names.join(':');
+    }
+    names.pop();
+  }
+}
+
+
+/**
+ * Our "url-format scopes" are things like:
+ *
+ *   * "https://identity.mozilla.com/apps/oldsync"
+ *   * "https://identity.mozilla.com/apps/oldsync/bookmarks#read"
+ *
+ * We'll accept basically any sanely-formed, canonicalized https://
+ * URL, and scope implication boils down to checking whether one
+ * URL is a child of another.
+ *
+ */
+function* getImplicantValuesForURLScope(value) {
+  if (! VALID_SCOPE_VALUE.test(value)) {
+    throw new Error('Invalid scope value: ' + value);
+  }
+  const url = new URL(value);
+  // Only https:// URLs are allowed.
+  if (url.protocol !== 'https:') {
+    throw new Error('Invalid scope value: ' + value);
+  }
+  // No credentials or query params are allowed.
+  if (url.username || url.password || url.query) {
+    throw new Error('Invalid scope value: ' + value);
+  }
+  // The pathname must be non-empty and not end in a slash.
+  if (! url.pathname || url.pathname.endsWith('/')) {
+    throw new Error('Invalid scope value: ' + value);
+  }
+  // The hash fragment must be alphnumeric.
+  if (url.hash && ! VALID_FRAGMENT_VALUE.test(url.hash)) {
+    throw new Error('Invalid scope value: ' + value);
+  }
+  // The URL must round-trip cleanly through a URL parse,
+  // to avoid any ambiguity in parsing.
+  if (url.href !== value) {
+    throw new Error('Invalid scope value: ' + value);
+  }
+  // All parent resource URLs will imply this scope.
+  // If it has a hash fragment, then this scope will also be
+  // implied by parent URLs with that same hash fragment.
+  const pathParts = url.pathname.split('/');
+  while (pathParts.length > 1) {
+    yield new URL(pathParts.join('/'), url).href;
+    if (url.hash) {
+      yield new URL(pathParts.join('/') + url.hash, url).href;
+    }
+    pathParts.pop();
+  }
+}
+
+
+module.exports = {
+
+  /**
+   * Parse a list of strings into a Scope object.
+   *
+   */
+  fromArray (scopesArray) {
+    return new ScopeSet(scopesArray);
+  },
+
+  /**
+   * Parse a space-delimited string into a Scope object.
+   *
+   * This function implements the semantics defined in RFC6749, where
+   * the "scope" input string represents a space-delimited list of
+   * case-sensitive strings identifying individual scope values.
+   *
+   */
+  fromString (scopesString) {
+    // Split the string by one or more space characters.
+    return new ScopeSet(scopesString.split(/ +/).filter(scopeString => {
+      return !! scopeString;
+    }));
+  },
+
+  /**
+   * Parse a url-encoded string into a Scope object.
+   *
+   * This function parses a Scope from a "scope" input string
+   * that has been url-encoded, as you might receive in the query
+   * parameter of an OAuth authorizaton request.  The list is thus
+   * delimited by `+` rather than ` `, and any percent-encoded
+   * characters in the scopes will be expanded.
+   *
+   */
+  fromURLEncodedString (encodedScopesString) {
+    // Split the string by a literal plus character.
+    return new ScopeSet(encodedScopesString.split(/\+/).filter(encodedScopeString => {
+      return !! encodedScopeString;
+    }).map(encodedScopeString => {
+      return decodeURIComponent(encodedScopeString);
+    }));
+  }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -18,5 +18,7 @@ describe('index:', () => {
     assert.isObject(index.metrics.amplitude);
     assert.isArray(index.l10n.supportedLanguages);
     assert.isFunction(index.l10n.localizeTimestamp);
+    assert.isFunction(index.oauth.scopes.fromString);
+    assert.isFunction(index.oauth.scopes.fromURLEncodedString);
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -18,5 +18,5 @@ describe('index:', () => {
     assert.isObject(index.metrics.amplitude);
     assert.isArray(index.l10n.supportedLanguages);
     assert.isFunction(index.l10n.localizeTimestamp);
-  })
+  });
 });

--- a/test/l10n/localizeTimestamp.js
+++ b/test/l10n/localizeTimestamp.js
@@ -20,7 +20,7 @@ describe('l10n/localizeTimestamp:', () => {
 
   it('throws if called without defaultLanguage', () => {
     assert.throws(() => localizeTimestamp({ supportedLanguages: [ 'en' ] }));
-  })
+  });
 
   describe('call with supported language:', () => {
     let format;

--- a/test/metrics/amplitude.js
+++ b/test/metrics/amplitude.js
@@ -126,7 +126,7 @@ describe('metrics/amplitude:', () => {
           utm_source: 'x',
           utm_term: 'y'
         });
-      })
+      });
 
       it('returned the correct result', () => {
         assert.deepEqual(result, {
@@ -182,7 +182,7 @@ describe('metrics/amplitude:', () => {
           flowId: 'c',
           uid: 'd'
         });
-      })
+      });
 
       it('returned the correct result', () => {
         assert.deepEqual(result, {
@@ -205,7 +205,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'wibble.blee' }, {});
-      })
+      });
 
       it('returned the correct event type', () => {
         assert.equal(result.event_type, 'fxa_reg - targetEvent4');
@@ -217,7 +217,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'wobble.glick.gluck' }, {});
-      })
+      });
 
       it('returned the correct event type', () => {
         assert.equal(result.event_type, 'fxa_login - glick.gluck');
@@ -229,7 +229,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'sms.ios' }, {});
-      })
+      });
 
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_connect_device - cadEvent');
@@ -253,7 +253,7 @@ describe('metrics/amplitude:', () => {
           },
           templateVersion: 'bar'
         });
-      })
+      });
 
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_email - emailEvent');
@@ -273,7 +273,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'disconnect.wibble.blee' }, {});
-      })
+      });
 
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_pref - disconnect_device');
@@ -286,7 +286,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'newsletter.optIn.wibble' }, {});
-      })
+      });
 
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_pref - newsletterEvent');
@@ -299,7 +299,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'wibble.blee' }, { service: 'gribble' });
-      })
+      });
 
       it('returned the correct event data', () => {
         assert.deepEqual(result.event_properties, {
@@ -315,7 +315,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'wibble.blee' }, { service: 'sync' });
-      })
+      });
 
       it('returned the correct event data', () => {
         assert.deepEqual(result.event_properties, { service: 'sync' });
@@ -328,7 +328,7 @@ describe('metrics/amplitude:', () => {
 
       before(() => {
         result = transform({ type: 'wibble.blee' }, { service: 'content-server' });
-      })
+      });
 
       it('returned the correct event data', () => {
         assert.deepEqual(result.event_properties, {});

--- a/test/oauth/scopes.js
+++ b/test/oauth/scopes.js
@@ -1,0 +1,296 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+
+describe('oauth/scopes:', () => {
+  let scopes;
+
+  before(() => {
+    scopes = require('../../oauth/scopes');
+  });
+
+  describe('valid implications', () => {
+    const VALID_IMPLICATIONS = [
+      // [A, B] => "A contains B"
+      ['profile:write', 'profile'],
+      ['profile', 'profile:email'],
+      ['profile:write', 'profile:email'],
+      ['profile:write', 'profile:email:write'],
+      ['profile:email:write', 'profile:email'],
+      ['profile profile:email:write', 'profile:email'],
+      ['profile profile:email:write', 'profile:display_name'],
+      ['profile https://identity.mozilla.com/apps/oldsync', 'profile'],
+      ['foo bar:baz', 'foo:dee'],
+      ['foo bar:baz', 'bar:baz'],
+      ['foo bar:baz', 'foo:mah:pa bar:baz:quux'],
+      ['profile https://identity.mozilla.com/apps/oldsync', 'https://identity.mozilla.com/apps/oldsync'],
+      ['https://identity.mozilla.com/apps/oldsync', 'https://identity.mozilla.com/apps/oldsync#read'],
+      ['https://identity.mozilla.com/apps/oldsync', 'https://identity.mozilla.com/apps/oldsync/bookmarks'],
+      ['https://identity.mozilla.com/apps/oldsync', 'https://identity.mozilla.com/apps/oldsync/bookmarks#read'],
+      ['https://identity.mozilla.com/apps/oldsync#read', 'https://identity.mozilla.com/apps/oldsync/bookmarks#read'],
+      ['https://identity.mozilla.com/apps/oldsync#read profile', 'https://identity.mozilla.com/apps/oldsync/bookmarks#read']
+    ];
+
+    VALID_IMPLICATIONS.forEach(([source, target]) => {
+      it(`scope "${source}" contains scope "${target}"`, () => {
+        source = scopes.fromString(source);
+        target = scopes.fromString(target);
+        assert.isTrue(source.contains(target));
+      });
+    });
+  });
+
+  describe('invalid implications', () => {
+    // [A, B] => "A does not contain B"
+    const INVALID_IMPLICATIONS = [
+      ['profile:email:write', 'profile'],
+      ['profile:email:write', 'profile:write'],
+      ['profile:email', 'profile:display_name'],
+      ['profilebogey', 'profile'],
+      ['foo bar:baz', 'bar'],
+      ['profile:write', 'https://identity.mozilla.com/apps/oldsync'],
+      ['profile profile:email:write', 'profile:write'],
+      ['https', 'https://identity.mozilla.com/apps/oldsync'],
+      ['https://identity.mozilla.com/apps/oldsync', 'profile'],
+      ['https://identity.mozilla.com/apps/oldsync#read', 'https://identity.mozila.com/apps/oldsync/bookmarks'],
+      ['https://identity.mozilla.com/apps/oldsync#write', 'https://identity.mozila.com/apps/oldsync/bookmarks#read'],
+      ['https://identity.mozilla.com/apps/oldsync/bookmarks', 'https://identity.mozila.com/apps/oldsync'],
+      ['https://identity.mozilla.com/apps/oldsync/bookmarks', 'https://identity.mozila.com/apps/oldsync/passwords'],
+      ['https://identity.mozilla.com/apps/oldsyncer', 'https://identity.mozila.com/apps/oldsync'],
+      ['https://identity.mozilla.com/apps/oldsync', 'https://identity.mozila.com/apps/oldsyncer'],
+      ['https://identity.mozilla.org/apps/oldsync', 'https://identity.mozila.com/apps/oldsync']
+    ];
+
+    INVALID_IMPLICATIONS.forEach(([source, target]) => {
+      it(`scope "${source}" does not contain scope "${target}"`, () => {
+        source = scopes.fromString(source);
+        target = scopes.fromString(target);
+        assert.isFalse(source.contains(target));
+      });
+    });
+  });
+
+  describe('invalid scope values', () => {
+    const INVALID_SCOPE_VALUES = [
+      'profile:email!:write',
+      ':',
+      '::',
+      ':profile',
+      'profile::email',
+      'profile profile\0:email',
+      'http://identity.mozilla.com/apps/oldsync',
+      'file:///etc/passwd',
+      'https://identity.mozilla.com/apps/oldsync/../notes',
+      'https://identity.mozilla.com/apps/oldsync/',
+      'https://identity.mozilla.com/apps/oldsync/#write',
+      'http://identity.mozilla.com/apps/oldsync#read!',
+      'http://identity.mozilla.com/apps/oldsync#read+write',
+      'http://identity.mozilla.com/apps/oldsync#read:write',
+      'http://identity.mozilla.com/apps/old:sync'
+    ];
+
+    INVALID_SCOPE_VALUES.forEach(source => {
+      it(`scope "${source}" is invalid`, () => {
+        assert.throws(() => scopes.fromString(source), Error, /^Invalid scope value/);
+      });
+    });
+
+    INVALID_SCOPE_VALUES.forEach(source => {
+      source = encodeURIComponent(source);
+      it(`url-encoded scope "${source}" is invalid`, () => {
+        assert.throws(() => scopes.fromURLEncodedString(source), Error, /^Invalid scope value/);
+      });
+    });
+
+    const INVALID_SCOPE_VALUES_WHEN_URIENCODED = [
+      'profile profile:email:write',
+      'profile%20profile:email:write',
+      'profile+profile::email',
+      'profile+profile:%3Aemail',
+      encodeURIComponent('http://identity.mozilla.com/apps/oldsync#read+write')
+    ];
+
+    INVALID_SCOPE_VALUES_WHEN_URIENCODED.forEach(source => {
+      it(`url-encoded scope "${source}" is invalid`, () => {
+        assert.throws(() => scopes.fromURLEncodedString(source), Error, /^Invalid scope value/);
+      });
+    });
+  });
+
+  describe('scope filtering', () => {
+    // [A, B, C] => "A filtered by B gives C"
+    const FILTERED_RESULTS = [
+      ['profile', 'profile', 'profile'],
+      ['profile', 'profile:write', 'profile'],
+      ['profile', 'profile:email', ''],
+      ['profile basket', 'profile', 'profile'],
+      ['basket profile:email', 'profile', 'profile:email'],
+      ['basket profile:email:write', 'profile:write basket', 'basket profile:email:write'],
+      ['basket profile:email:write', 'profile:write basket', 'basket profile:email:write'],
+      ['https://identity.mozilla.com/apps/oldsync#read',
+        'profile https://identity.mozilla.com/apps/oldsync',
+        'https://identity.mozilla.com/apps/oldsync#read'],
+      ['https://identity.mozilla.com/apps/oldsync/bookmarks#read https://identity.mozilla.com/apps/oldsync/passwords#write',
+        'profile https://identity.mozilla.com/apps/oldsync',
+        'https://identity.mozilla.com/apps/oldsync/bookmarks#read https://identity.mozilla.com/apps/oldsync/passwords#write'],
+      ['https://identity.mozilla.com/apps/oldsync/bookmarks#read https://identity.mozilla.com/apps/oldsync/passwords#write',
+        'profile https://identity.mozilla.com/apps/oldsync#write',
+        'https://identity.mozilla.com/apps/oldsync/passwords#write']
+    ];
+
+    FILTERED_RESULTS.forEach(([s1, s2, result]) => {
+      it(`scope "${s1}" filtered by "${s2}" gives correct result`, () => {
+        s1 = scopes.fromString(s1);
+        s2 = scopes.fromString(s2);
+        assert.deepEqual(s1.filtered(s2).toString(), result);
+      });
+    });
+  });
+
+  describe('scope intersection', () => {
+    // [A, B] => "A intersects with B"
+    const VALID_INTERSECTIONS = [
+      ['profile', 'profile'],
+      ['profile', 'profile:write'],
+      ['profile', 'profile:email', ''],
+      ['profile:write', 'profile'],
+      ['profile', 'profile:email'],
+      ['profile basket', 'profile'],
+      ['profile basket', 'profile oauth'],
+      ['profile basket', 'basket'],
+      ['profile basket', 'basket:write'],
+      ['profile:write basket', 'profile:write']
+    ];
+
+    VALID_INTERSECTIONS.forEach(([s1, s2]) => {
+      it(`scope "${s1}" intersects with "${s2}"`, () => {
+        s1 = scopes.fromString(s1);
+        s2 = scopes.fromString(s2);
+        assert.ok(s1.intersects(s2));
+      });
+    });
+
+    // [A, B] => "A does not intersect with B"
+    const INVALID_INTERSECTIONS = [
+      ['profile', 'basket'],
+      ['profile oauth', 'basket'],
+    ];
+
+    INVALID_INTERSECTIONS.forEach(([s1, s2]) => {
+      it(`scope "${s1}" does not intersect with "${s2}"`, () => {
+        s1 = scopes.fromString(s1);
+        s2 = scopes.fromString(s2);
+        assert.ok(! s1.intersects(s2));
+      });
+    });
+  });
+
+  describe('scope implicant expansion', () => {
+    // [A, B] => "A has implicants B"
+    const IMPLICANT_RESULTS = [
+      ['profile', 'profile:write profile'],
+      ['profile:write', 'profile:write'],
+      ['profile:email:write profile:amr', [
+        'profile:email:write',
+        'profile:write',
+        'profile:amr:write',
+        'profile:amr',
+        'profile'].join(' ')],
+      ['profile:email https://identity.mozilla.com/apps/oldsync', [
+        'profile:email:write',
+        'profile:email',
+        'profile:write',
+        'profile',
+        'https://identity.mozilla.com/apps/oldsync',
+        'https://identity.mozilla.com/apps'].join(' ')],
+      ['https://identity.mozilla.com/apps/oldsync/bookmarks#read', [
+        'https://identity.mozilla.com/apps/oldsync/bookmarks',
+        'https://identity.mozilla.com/apps/oldsync/bookmarks#read',
+        'https://identity.mozilla.com/apps/oldsync',
+        'https://identity.mozilla.com/apps/oldsync#read',
+        'https://identity.mozilla.com/apps',
+        'https://identity.mozilla.com/apps#read'].join(' ')]
+    ];
+
+    IMPLICANT_RESULTS.forEach(([source, result]) => {
+      it(`scope "${source}" has correct set of implicants`, () => {
+        source = scopes.fromString(source);
+        assert.deepEqual(source.getImplicantValues().join(' '), result);
+      });
+    });
+  });
+
+  describe('scope union', () => {
+    // [A, B, C] => "A.union(B) is C"
+    const UNION_RESULTS = [
+      ['profile', 'profile:email', 'profile'],
+      ['profile:write https://identity.mozilla.com/apps/oldsync', 'profile:write', 'profile:write https://identity.mozilla.com/apps/oldsync'],
+      ['one two three', 'two three four', 'one two three four'],
+      ['one two:too three:won', 'two:write three:to four', 'one three:won two:write three:to four']
+    ];
+
+    UNION_RESULTS.forEach(([s1, s2, result]) => {
+      it(`scopes "${s1}" and "${s2}" union correctly`, () => {
+        s1 = scopes.fromString(s1);
+        s2 = scopes.fromString(s2);
+        assert.deepEqual(s1.union(s2).toString(), result);
+      });
+    });
+  });
+
+  describe('scope difference', () => {
+    // [A, B, C] => "A.difference(B) is C"
+    const DIFFERENCE_RESULTS = [
+      ['profile', 'profile', ''],
+      ['profile:email', 'profile', ''],
+      ['profile', 'profile:email', 'profile'],
+      ['profile:email clients:abcd', 'profile:email profile:display_name clients', ''],
+      ['profile:email profile:display_name clients', 'profile:email clients:abcd', 'profile:display_name clients'],
+      ['profile:email profile:display_name', 'profile:email', 'profile:display_name'],
+      ['profile:write https://identity.mozilla.com/apps/oldsync',
+        'profile:write', 'https://identity.mozilla.com/apps/oldsync'],
+      ['profile:write https://identity.mozilla.com/apps/oldsync',
+        'https://identity.mozilla.com/apps/oldsync', 'profile:write'],
+      ['one two three', 'two three four', 'one']
+    ];
+
+    DIFFERENCE_RESULTS.forEach(([s1, s2, result]) => {
+      it(`scopes "${s1}" and "${s2}" difference correctly`, () => {
+        s1 = scopes.fromString(s1);
+        s2 = scopes.fromString(s2);
+        assert.deepEqual(s1.difference(s2).toString(), result);
+      });
+    });
+  });
+
+  describe('emptiness checking', () => {
+    it('empty string scope is, in fact, empty', () => {
+      assert.ok(scopes.fromString('').isEmpty());
+    });
+
+    it('non-empty string scope is, in fact, non-empty', () => {
+      assert.ok(! scopes.fromString('profile').isEmpty());
+    });
+  });
+
+  describe('in-place add', () => {
+    it('correctly aggregates scopes over multiple calls to .add()', () => {
+      const s = scopes.fromString('one');
+      assert.deepEqual(s.toString(), 'one');
+      s.add('two:too');
+      assert.deepEqual(s.toString(), 'one two:too');
+      s.add(['one', 'three']);
+      assert.deepEqual(s.toString(), 'one two:too three');
+      s.add(['one', 'two:too:write']);
+      assert.deepEqual(s.toString(), 'one three two:too:write');
+      s.add(['three', 'two']);
+      assert.deepEqual(s.toString(), 'one three two:too:write two');
+      s.add(['three:write', 'two:write']);
+      assert.deepEqual(s.toString(), 'one three:write two:write');
+    });
+  });
+});


### PR DESCRIPTION
Connects to https://github.com/mozilla/fxa-oauth-server/issues/575

As part of https://github.com/mozilla/fxa-oauth-server/pull/551, let's consolidate our OAuth-scope-checking code in a single place.  We currently have separate implementations of subsets of this logic in auth-server, profile-server and oauth-server, this adds a bunch of testcases and extracts it into a shared lb.

@mozilla/fxa-devs r?
