### PR TITLE
refactor(metrics): pull email type definitions back up to the caller

### DIFF
--- a/metrics/amplitude.js
+++ b/metrics/amplitude.js
@@ -32,33 +32,6 @@ const CONNECT_DEVICE_FLOWS = {
   sms: 'sms'
 };
 
-const EMAIL_TYPES = {
-  // Indexed by content server view name
-  'complete-reset-password': 'reset_password',
-  'complete-signin': 'login',
-  'verify-email': 'registration',
-  // Indexed by auth server template name
-  lowRecoveryCodesEmail: '2fa',
-  newDeviceLoginEmail: 'login',
-  passwordChangedEmail: 'change_password',
-  passwordResetEmail: 'reset_password',
-  passwordResetRequiredEmail: 'reset_password',
-  postChangePrimaryEmail: 'change_email',
-  postRemoveSecondaryEmail: 'secondary_email',
-  postVerifyEmail: 'registration',
-  postVerifySecondaryEmail: 'secondary_email',
-  postConsumeRecoveryCodeEmail: '2fa',
-  postNewRecoveryCodesEmail: '2fa',
-  recoveryEmail: 'reset_password',
-  unblockCode: 'unblock',
-  verifyEmail: 'registration',
-  verifyLoginEmail: 'login',
-  verifyLoginCodeEmail: 'login',
-  verifyPrimaryEmail: 'verify',
-  verifySyncEmail: 'registration',
-  verifySecondaryEmail: 'secondary_email'
-}
-
 const NEWSLETTER_STATES = {
   optIn: 'subscribed',
   optOut: 'unsubscribed',
@@ -92,7 +65,7 @@ function mapConnectDeviceFlow (eventType, eventCategory, eventTarget) {
 }
 
 function mapEmailType (eventType, eventCategory, eventTarget, data) {
-  const email_type = EMAIL_TYPES[eventCategory];
+  const email_type = data.emailTypes[eventCategory];
 
   if (email_type) {
     const result = { email_type, email_provider: data.emailDomain };
@@ -115,8 +88,6 @@ function mapDisconnectReason (eventType, eventCategory) {
 
 module.exports = {
   GROUPS,
-
-  EMAIL_TYPES,
 
   /**
    * Initialize an amplitude event mapper. You can read more about the amplitude

--- a/test/metrics/amplitude.js
+++ b/test/metrics/amplitude.js
@@ -29,32 +29,6 @@ describe('metrics/amplitude:', () => {
     assert.isString(amplitude.GROUPS.sms);
   });
 
-  it('exports the email types', () => {
-    assert.isObject(amplitude.EMAIL_TYPES);
-    assert.isString(amplitude.EMAIL_TYPES['complete-reset-password']);
-    assert.isString(amplitude.EMAIL_TYPES['complete-signin']);
-    assert.isString(amplitude.EMAIL_TYPES['verify-email']);
-    assert.isString(amplitude.EMAIL_TYPES.lowRecoveryCodesEmail);
-    assert.isString(amplitude.EMAIL_TYPES.newDeviceLoginEmail);
-    assert.isString(amplitude.EMAIL_TYPES.passwordChangedEmail);
-    assert.isString(amplitude.EMAIL_TYPES.passwordResetEmail);
-    assert.isString(amplitude.EMAIL_TYPES.passwordResetRequiredEmail);
-    assert.isString(amplitude.EMAIL_TYPES.postChangePrimaryEmail);
-    assert.isString(amplitude.EMAIL_TYPES.postRemoveSecondaryEmail);
-    assert.isString(amplitude.EMAIL_TYPES.postVerifyEmail);
-    assert.isString(amplitude.EMAIL_TYPES.postVerifySecondaryEmail);
-    assert.isString(amplitude.EMAIL_TYPES.postConsumeRecoveryCodeEmail);
-    assert.isString(amplitude.EMAIL_TYPES.postNewRecoveryCodesEmail);
-    assert.isString(amplitude.EMAIL_TYPES.recoveryEmail);
-    assert.isString(amplitude.EMAIL_TYPES.unblockCode);
-    assert.isString(amplitude.EMAIL_TYPES.verifyEmail);
-    assert.isString(amplitude.EMAIL_TYPES.verifyLoginEmail);
-    assert.isString(amplitude.EMAIL_TYPES.verifyLoginCodeEmail);
-    assert.isString(amplitude.EMAIL_TYPES.verifyPrimaryEmail);
-    assert.isString(amplitude.EMAIL_TYPES.verifySyncEmail);
-    assert.isString(amplitude.EMAIL_TYPES.verifySecondaryEmail);
-  });
-
   it('exports an initialize method', () => {
     assert.isFunction(amplitude.initialize);
     assert.lengthOf(amplitude.initialize, 3);
@@ -256,6 +230,9 @@ describe('metrics/amplitude:', () => {
       before(() => {
         result = transform({ type: 'verifySecondaryEmail.wibble' }, {
           emailDomain: 'foo',
+          emailTypes: {
+            verifySecondaryEmail: 'secondary_email'
+          },
           templateVersion: 'bar'
         });
       })


### PR DESCRIPTION
Related to #23.

I've got equivalent branches in the auth and content servers that define `data.emailTypes` accordingly, which I'll PR once this one is merged.

@mozilla/fxa-devs r?