### PR TITLE
feat(metrics): add event properties for email sender and service

### DIFF
--- a/metrics/amplitude.js
+++ b/metrics/amplitude.js
@@ -68,7 +68,12 @@ function mapEmailType (eventType, eventCategory, eventTarget, data) {
   const email_type = data.emailTypes[eventCategory];
 
   if (email_type) {
-    const result = { email_type, email_provider: data.emailDomain };
+    const result = {
+      email_type,
+      email_provider: data.emailDomain,
+      email_sender: data.emailSender,
+      email_service: data.emailService
+    };
 
     const { templateVersion } = data;
     if (templateVersion) {

--- a/test/metrics/amplitude.js
+++ b/test/metrics/amplitude.js
@@ -230,6 +230,8 @@ describe('metrics/amplitude:', () => {
       before(() => {
         result = transform({ type: 'verifySecondaryEmail.wibble' }, {
           emailDomain: 'foo',
+          emailSender: 'ses',
+          emailService: 'fxa-email-service',
           emailTypes: {
             verifySecondaryEmail: 'secondary_email'
           },
@@ -241,6 +243,8 @@ describe('metrics/amplitude:', () => {
         assert.equal(result.event_type, 'fxa_email - emailEvent');
         assert.deepEqual(result.event_properties, {
           email_provider: 'foo',
+          email_sender: 'ses',
+          email_service: 'fxa-email-service',
           email_template: 'verifySecondaryEmail',
           email_type: 'secondary_email',
           email_version: 'bar'


### PR DESCRIPTION
Related to mozilla/fxa-auth-server#2499.

Adds some event properties that we can use to track metrics for the new email service. Equivalent auth server PR to follow.

@mozilla/fxa-devs r?