### PR TITLE
feat(metrics): Allow a function for `event` in the fuzzy types.

### DIFF
--- a/metrics/amplitude.js
+++ b/metrics/amplitude.js
@@ -107,7 +107,7 @@ module.exports = {
    * @param {Object} services An object of client-id:service-name mappings.
    *
    * @param {Object} events   An object of name:definition event mappings, where
-   *                          each defintion value is itself an object with `group`
+   *                          each definition value is itself an object with `group`
    *                          and `event` string properties.
    *
    * @param {Map} fuzzyEvents A map of regex:definition event mappings. Each regex
@@ -165,6 +165,13 @@ module.exports = {
 
       if (mapping) {
         eventType = mapping.event;
+        if (typeof eventType === 'function') {
+          eventType = eventType(eventCategory, eventTarget)
+          if (! eventType) {
+            return;
+          }
+        }
+
         let eventGroup = mapping.group;
         if (typeof eventGroup === 'function') {
           eventGroup = eventGroup(eventCategory);

--- a/test/metrics/amplitude.js
+++ b/test/metrics/amplitude.js
@@ -59,6 +59,10 @@ describe('metrics/amplitude:', () => {
           group: eventCategory => eventCategory === 'wibble' ? amplitude.GROUPS.registration : null,
           event: 'targetEvent4'
         } ],
+        [ /wobble\.(\w+)\.(\w+)/, {
+          group: amplitude.GROUPS.login,
+          event: (eventCategory, eventTarget) => `${eventCategory}.${eventTarget}`
+        } ],
         [ /(sms)\.(\w+)/, {
           group: amplitude.GROUPS.connectDevice,
           event: 'cadEvent'
@@ -205,6 +209,18 @@ describe('metrics/amplitude:', () => {
 
       it('returned the correct event type', () => {
         assert.equal(result.event_type, 'fxa_reg - targetEvent4');
+      });
+    });
+
+    describe('transform a fuzzy event with an event function:', () => {
+      let result;
+
+      before(() => {
+        result = transform({ type: 'wobble.glick.gluck' }, {});
+      })
+
+      it('returned the correct event type', () => {
+        assert.equal(result.event_type, 'fxa_login - glick.gluck');
       });
     });
 


### PR DESCRIPTION
If `event` in a fuzzy event is a function, the result
of the function will become the eventType. Function is passed
the `eventCategory` and `eventTarget`

ref https://github.com/mozilla/fxa-content-server/issues/6349

@philbooth - r?