### PR TITLE
fix(l10n): ensure the correct language is selected in localizeTimestamp

### DIFF
--- a/l10n/localizeTimestamp.js
+++ b/l10n/localizeTimestamp.js
@@ -24,6 +24,9 @@ module.exports = function (options) {
   if (supportedLanguages.length === 0) {
     // must support at least one language.
     supportedLanguages = [defaultLanguage];
+  } else {
+    // default language must come first
+    supportedLanguages.unshift(defaultLanguage);
   }
 
   // setup supported languages
@@ -54,7 +57,7 @@ module.exports = function (options) {
           if (parseHeader && Array.isArray(parseHeader) && parseHeader.length > 0 && parseHeader[0].language) {
             // the 'accept-language' will fallback to unsupported locale if it cannot find anything
             // we do not want that, only set language if it is a supported locale.
-            if (supportedLanguages.indexOf(parseHeader[0].language)) {
+            if (supportedLanguages.indexOf(parseHeader[0].language) !== -1) {
               language = parseHeader[0].language;
             }
           }

--- a/test/l10n/localizeTimestamp.js
+++ b/test/l10n/localizeTimestamp.js
@@ -27,7 +27,7 @@ describe('l10n/localizeTimestamp:', () => {
 
     before(() => {
       format = localizeTimestamp({
-        supportedLanguages: [ 'en', 'en-GB', 'es', 'ru' ],
+        supportedLanguages: [ 'ar', 'es', 'ru' ],
         defaultLanguage: 'en'
       }).format;
     });
@@ -46,7 +46,7 @@ describe('l10n/localizeTimestamp:', () => {
     });
 
     it('returns the requested language if called with an Accept-Language header', () => {
-      assert.equal(format(Date.now() - 1, 'qu,ru;q=0.8,en-GB;q=0.5,en;q=0.3'), 'несколько секунд назад');
+      assert.equal(format(Date.now() - 1, 'ru,en-GB;q=0.5,en;q=0.3'), 'несколько секунд назад');
     });
 
     it('returns the requested language if called with a single language', () => {
@@ -57,12 +57,20 @@ describe('l10n/localizeTimestamp:', () => {
       assert.equal(format(Date.now() - 1, 'es-mx, ru'), 'hace unos segundos');
     });
 
+    it('returns a fallback language if called with unsupported language variations', () => {
+      assert.equal(format(Date.now() - 1, 'de, fr;q=0.8, ru;q=0.5'), 'несколько секунд назад');
+    });
+
     it('returns the default language if called with an unsupported language', () => {
       assert.equal(format(Date.now() - 1, 'qu'), 'a few seconds ago');
     });
 
-    it('returns the default language if called with no language', () => {
-      assert.equal(format(Date.now() - 1, 'q=0.8'), 'a few seconds ago');
+    it('returns the default language if called with the default language', () => {
+      assert.equal(format(Date.now() - 1, 'en'), 'a few seconds ago');
+    });
+
+    it('returns the first supported language if called with the first supported language', () => {
+      assert.equal(format(Date.now() - 1, 'ar'), 'منذ ثانية واحدة');
     });
   });
 


### PR DESCRIPTION
Fixes #33.

The test of `supportedLanguages.indexOf` was mistakenly checking against `0` instead of `-1`. This meant that the first item in our list of supported languages, arabic, was never being matched and other, unsupported ones were being matched.

Furthermore, the `accept-languages` package assumes it is initialised with an array of languages that are sorted in order of precedence. This meant our `defaultLanguage` option was effectively being ignored because it was not at the start of the list.

This change fixes both issues and tweaks the tests so that they will fail if either one regresses in the future.

@mozilla/fxa-devs r?