### PR TITLE
revert(metrics): Revert "feat(metrics): Use the service name or client_id as the entrypoint if none given."

### DIFF
--- a/metrics/amplitude.js
+++ b/metrics/amplitude.js
@@ -180,7 +180,7 @@ module.exports = {
           }
         }
 
-        const properties = pruneUnsetValues({
+        return pruneUnsetValues({
           op: 'amplitudeEvent',
           event_type: `${eventGroup} - ${eventType}`,
           time: event.time,
@@ -197,21 +197,6 @@ module.exports = {
           event_properties: mapEventProperties(eventType, eventGroup, eventCategory, eventTarget, data),
           user_properties: mapUserProperties(eventGroup, eventCategory, data)
         });
-
-        if (! properties.user_properties.entrypoint) {
-          // If no entrypoint is specified, use the service name or client_id
-          // as the entrypoint to minimize occurrences of "entrypoint=none"
-          // results in Amplitude. service name is preferred because
-          // it's human readable.
-          // See https://github.com/mozilla/fxa-content-server/issues/6757
-          if (properties.event_properties.service && properties.event_properties.service !== 'undefined_oauth') {
-            properties.user_properties.entrypoint = properties.event_properties.service;
-          } else if (properties.event_properties.oauth_client_id) {
-            properties.user_properties.entrypoint = properties.event_properties.oauth_client_id;
-          }
-        }
-
-        return properties;
       }
     };
 

--- a/test/metrics/amplitude.js
+++ b/test/metrics/amplitude.js
@@ -294,7 +294,7 @@ describe('metrics/amplitude:', () => {
       });
     });
 
-    describe('transform an event with service=unknown client_id:', () => {
+    describe('transform an event with undefined service:', () => {
       let result;
 
       before(() => {
@@ -306,29 +306,7 @@ describe('metrics/amplitude:', () => {
           oauth_client_id: 'gribble',
           service: 'undefined_oauth'
         });
-        assert.deepEqual(result.user_properties, {
-          '$append': { fxa_services_used: 'undefined_oauth' },
-          entrypoint: 'gribble'
-        });
-      });
-    });
-
-    describe('transform an event with service=known client_id:', () => {
-      let result;
-
-      before(() => {
-        result = transform({ type: 'wibble.blee' }, { service: 'foo' });
-      });
-
-      it('returned the correct event data', () => {
-        assert.deepEqual(result.event_properties, {
-          oauth_client_id: 'foo',
-          service: 'bar'
-        });
-        assert.deepEqual(result.user_properties, {
-          '$append': { fxa_services_used: 'bar' },
-          entrypoint: 'bar'
-        });
+        assert.deepEqual(result.user_properties, { '$append': { fxa_services_used: 'undefined_oauth' } });
       });
     });
 
@@ -341,10 +319,7 @@ describe('metrics/amplitude:', () => {
 
       it('returned the correct event data', () => {
         assert.deepEqual(result.event_properties, { service: 'sync' });
-        assert.deepEqual(result.user_properties, {
-          '$append': { fxa_services_used: 'sync' },
-          entrypoint: 'sync'
-        });
+        assert.deepEqual(result.user_properties, { '$append': { fxa_services_used: 'sync' } });
       });
     });
 


### PR DESCRIPTION
This reverts commit 6f2792b2c834ffdb4e6f93ada004872c4bb17b20.

fixes #46 

@mozilla/fxa-devs - r?