### PR TITLE
feat(metrics): Add the `fxa_notify` group.

### DIFF
--- a/metrics/amplitude.js
+++ b/metrics/amplitude.js
@@ -20,6 +20,7 @@ const GROUPS = {
   email: 'fxa_email',
   emailFirst: 'fxa_email_first',
   login: 'fxa_login',
+  notify: 'fxa_notify',
   registration: 'fxa_reg',
   settings: 'fxa_pref',
   sms: 'fxa_sms'

--- a/test/metrics/amplitude.js
+++ b/test/metrics/amplitude.js
@@ -24,6 +24,7 @@ describe('metrics/amplitude:', () => {
     assert.isString(amplitude.GROUPS.email);
     assert.isString(amplitude.GROUPS.emailFirst);
     assert.isString(amplitude.GROUPS.login);
+    assert.isString(amplitude.GROUPS.notify);
     assert.isString(amplitude.GROUPS.registration);
     assert.isString(amplitude.GROUPS.settings);
     assert.isString(amplitude.GROUPS.sms);


### PR DESCRIPTION
This will be used for generic notifications, such as when
a user clicks on a "Download Firefox" button from the
"Upgrade Firefox" screen.

blocks mozilla/fxa-content-server#6895

@irrationalagent - r?