### PR TITLE
refactor(redis): extract the auth server's redis abstraction

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,9 @@ plugins:
   - fxa
 extends: plugin:fxa/server
 
+parserOptions:
+  ecmaVersion: 2018
+
 env:
     mocha: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ node_js:
 
 sudo: false
 
+services:
+  - redis-server
+
 notifications:
   irc:
     channels:

--- a/index.js
+++ b/index.js
@@ -1,16 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
 
 module.exports = {
   email: {
     popularDomains: require('./email/popularDomains')
   },
-  metrics: {
-    amplitude: require('./metrics/amplitude')
-  },
   l10n: {
     localizeTimestamp: require('./l10n/localizeTimestamp'),
     supportedLanguages: require('./l10n/supportedLanguages')
   },
+  metrics: {
+    amplitude: require('./metrics/amplitude')
+  },
   oauth: {
     scopes: require('./oauth/scopes')
-  }
+  },
+  promise: require('./promise'),
+  redis: require('./redis')
 };

--- a/package.json
+++ b/package.json
@@ -27,10 +27,15 @@
     "chai": "4.1.2",
     "eslint": "4.19.1",
     "eslint-plugin-fxa": "git://github.com/mozilla/eslint-plugin-fxa.git#e082927b4c6dc17d21414e35f4c94312adbaba92",
-    "mocha": "5.0.5"
+    "mocha": "5.0.5",
+    "proxyquire": "2.1.0",
+    "sinon": "7.2.5"
   },
   "dependencies": {
     "accept-language": "2.0.17",
-    "moment": "2.20.1"
+    "bluebird": "3.5.3",
+    "generic-pool": "3.6.1",
+    "moment": "2.20.1",
+    "redis": "2.8.0"
   }
 }

--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+module.exports = require('bluebird');

--- a/redis/connection.js
+++ b/redis/connection.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const Promise = require('../promise');
+
+module.exports = (log, client) => {
+  let isUpdating = false;
+  let destroyPromise;
+
+  return {
+    get (key) {
+      return client.getAsync(key);
+    },
+
+    set (key, value) {
+      return client.setAsync(key, value);
+    },
+
+    del (key) {
+      return client.delAsync(key);
+    },
+
+    /**
+     * To ensure safe update semantics in the presence of concurrency,
+     * we lean on Redis' WATCH, MULTI and EXEC commands so that updates
+     * run as a transaction and will fail if the data changes underneath
+     * them. You can read more about this in the Redis docs:
+     *
+     *   https://redis.io/topics/transactions
+     *
+     * @param key {String} The key to update
+     * @param getUpdatedValue {Function} A callback that receives the current value
+     *                                   and returns the updated value. May return a
+     *                                   promise or the raw updated value.
+     */
+    async update (key, getUpdatedValue) {
+      if (isUpdating) {
+        log.error('redis.update.conflict', { key });
+        throw new Error('redis.update.conflict');
+      }
+
+      let result;
+      isUpdating = true;
+
+      try {
+        await client.watchAsync(key);
+
+        const value = await getUpdatedValue(await client.getAsync(key));
+        const multi = client.multi();
+
+        if (value) {
+          multi.set(key, value);
+        } else {
+          multi.del(key);
+        }
+
+        result = await multi.execAsync();
+      } catch (error) {
+        client.unwatch();
+        log.error('redis.update.error', { key, error: error.message });
+        isUpdating = false;
+        throw error;
+      }
+
+      isUpdating = false;
+      if (! result) {
+        // Really this isn't an error as such, it just indicates that
+        // this function is operating sanely in concurrent conditions.
+        log.warn('redis.watch.conflict', { key });
+        throw new Error('redis.watch.conflict');
+      }
+    },
+
+    destroy () {
+      if (! destroyPromise) {
+        destroyPromise = new Promise(resolve => {
+          client.quit();
+          client.on('end', resolve);
+        });
+      }
+
+      return destroyPromise;
+    },
+
+    isValid () {
+      return ! destroyPromise;
+    }
+  };
+};

--- a/redis/index.js
+++ b/redis/index.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This module presents a "safe" interface to redis/pool and redis/connection,
+// where "safe" means "always acquires a new connection and always releases that
+// connection back to the pool at the end, regardless of any errors that may have
+// occurred". You do not need to worry about acquiring or releasing connections
+// yourself.
+//
+// Usage:
+//
+//   const redis = require('fxa-shared/redis');
+//
+//   redis.get(key)
+//     .then(value => {
+//       // :)
+//     })
+//     .catch(error => {
+//       // :(
+//     });
+//
+//   redis.set(key, value)
+//     .then(() => {
+//       // :)
+//     })
+//     .catch(error => {
+//       // :(
+//     });
+//
+//   redis.del(key)
+//     .then(() => {
+//       // :)
+//     })
+//     .catch(error => {
+//       // :(
+//     });
+//
+//   redis.update(key, value => updatedValue)
+//     .then(() => {
+//       // :)
+//     })
+//     .catch(error => {
+//       // :(
+//     });
+
+'use strict';
+
+const Promise = require('../promise');
+
+const REDIS_COMMANDS = [ 'get', 'set', 'del', 'update' ];
+
+module.exports = (config, log) => {
+  if (! config.enabled) {
+    log.info('redis.disabled');
+    return;
+  }
+
+  log.info('redis.enabled', { config });
+
+  const pool = require('./pool')(config, log);
+
+  return REDIS_COMMANDS.reduce((result, command) => {
+    result[command] = (...args) => Promise.using(pool.acquire(), connection => connection[command](...args));
+    return result;
+  }, {
+    close: () => pool.close()
+  });
+};

--- a/redis/pool.js
+++ b/redis/pool.js
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const genericPool = require('generic-pool');
+const Promise = require('../promise');
+const redis = require('redis');
+const redisConnection = require('./connection');
+
+Promise.promisifyAll(redis.RedisClient.prototype);
+Promise.promisifyAll(redis.Multi.prototype);
+
+module.exports = (config, log) => {
+  const redisConfig = {
+    host: config.host,
+    port: config.port,
+    prefix: config.prefix,
+    // Prefer redis to fail fast than wait indefinitely for reconnection
+    enable_offline_queue: false
+  };
+
+  const redisFactory = {
+    create () {
+      return new Promise((resolve, reject) => {
+        let connection;
+
+        const client = redis.createClient(Object.assign({}, redisConfig, {
+          retry_strategy ({ attempt }) {
+            if (attempt <= config.retryCount) {
+              return config.initialBackoff * Math.pow(2, attempt - 1);
+            }
+
+            if (connection) {
+              // It's too late to reject here because the connection was
+              // already added to the pool. Destroy it instead.
+              connection.destroy();
+            } else {
+              reject(new Error('redis.connection.error'));
+            }
+          }
+        }));
+
+        client.on('ready', () => {
+          if (! connection) {
+            connection = redisConnection(log, client);
+            resolve(connection);
+          }
+        });
+
+        client.on('error', error => {
+          log.error('redis.error', { error: error.message });
+        });
+      });
+    },
+
+    validate (connection) {
+      return connection.isValid();
+    },
+
+    destroy (connection) {
+      return connection.destroy();
+    }
+  };
+
+  const acquireTimeoutMillis = new Array(config.retryCount)
+    .fill(0)
+    .reduce((total, _, index) => {
+      return total + config.initialBackoff * Math.pow(2, index);
+    }, 0);
+
+  const pool = genericPool.createPool(redisFactory, {
+    acquireTimeoutMillis,
+    autostart: true,
+    max: config.maxConnections,
+    maxWaitingClients: config.maxPending,
+    min: config.minConnections,
+    Promise,
+    testOnBorrow: true
+  });
+
+  pool.on('factoryCreateError', error => log.error('redisFactory.error', { error: error.message }));
+
+  return {
+    /**
+     * Acquire a single-use Redis connection. Must be consumed via Promise.using().
+     *
+     * @return {Disposer} A bluebird disposer object
+     */
+    acquire () {
+      return pool.acquire().disposer(connection => pool.release(connection));
+    },
+
+    /**
+     * Close the pool, releasing any network connections.
+     */
+    close () {
+      return pool.drain().then(() => pool.clear());
+    }
+  };
+};

--- a/test/redis/connection.js
+++ b/test/redis/connection.js
@@ -1,0 +1,508 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const { assert } = require('chai');
+const Promise = require(`${ROOT_DIR}/promise`);
+const redisConnection = require(`${ROOT_DIR}/redis/connection`);
+const sinon = require('sinon');
+
+describe('redis/connection:', () => {
+  let log, redisClient, redisMulti, connection, getValue;
+
+  beforeEach(() => {
+    log = {
+      error: sinon.spy(),
+      info: sinon.spy(),
+      warn: sinon.spy()
+    };
+    redisClient = {
+      on: sinon.spy(),
+      getAsync: sinon.spy(() => Promise.resolve('mock get result')),
+      setAsync: sinon.spy(() => Promise.resolve()),
+      delAsync: sinon.spy(() => Promise.resolve()),
+      watchAsync: sinon.spy(() => Promise.resolve()),
+      multi: sinon.spy(() => redisMulti),
+      unwatch: sinon.spy(),
+      quit: sinon.spy()
+    };
+    redisMulti = {
+      execAsync: sinon.spy(() => Promise.resolve(true)),
+      set: sinon.spy(),
+      del: sinon.spy()
+    };
+    connection = redisConnection(log, redisClient);
+    getValue = sinon.spy(() => 'mock value');
+  });
+
+  it('redisConnection.isValid returns true', () => {
+    assert.isTrue(connection.isValid());
+  });
+
+  describe('redisConnection.get:', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await connection.get('wibble');
+    });
+
+    it('returned the get result', () => {
+      assert.equal(result, 'mock get result');
+    });
+
+    it('called redisClient.get correctly', () => {
+      assert.equal(redisClient.getAsync.callCount, 1);
+      const args = redisClient.getAsync.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'wibble');
+    });
+  });
+
+  describe('redisConnection.set:', () => {
+    beforeEach(() => {
+      return connection.set('wibble', 'blee');
+    });
+
+    it('called redisClient.set correctly', () => {
+      assert.equal(redisClient.setAsync.callCount, 1);
+      const args = redisClient.setAsync.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'wibble');
+      assert.equal(args[1], 'blee');
+    });
+  });
+
+  describe('redisConnection.del:', () => {
+    beforeEach(() => {
+      return connection.del('wibble');
+    });
+
+    it('called redisClient.del correctly', () => {
+      assert.equal(redisClient.delAsync.callCount, 1);
+      const args = redisClient.delAsync.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'wibble');
+    });
+  });
+
+  describe('redisConnection.update:', () => {
+    beforeEach(() => {
+      return connection.update('wibble', getValue);
+    });
+
+    it('called redisClient.watch correctly', () => {
+      assert.equal(redisClient.watchAsync.callCount, 1);
+      const args = redisClient.watchAsync.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'wibble');
+    });
+
+    it('called redisClient.get correctly', () => {
+      assert.equal(redisClient.getAsync.callCount, 1);
+      const args = redisClient.getAsync.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'wibble');
+    });
+
+    it('called getValue correctly', () => {
+      assert.equal(getValue.callCount, 1);
+      const args = getValue.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'mock get result');
+    });
+
+    it('called redisClient.multi correctly', () => {
+      assert.equal(redisClient.multi.callCount, 1);
+      assert.lengthOf(redisClient.multi.args[0], 0);
+    });
+
+    it('called redisMulti.set correctly', () => {
+      assert.equal(redisMulti.set.callCount, 1);
+      const args = redisMulti.set.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'wibble');
+      assert.equal(args[1], 'mock value');
+    });
+
+    it('called redisMulti.exec correctly', () => {
+      assert.equal(redisMulti.execAsync.callCount, 1);
+      assert.lengthOf(redisMulti.execAsync.args[0], 0);
+    });
+
+    it('did not call redisMulti.del', () => {
+      assert.equal(redisMulti.del.callCount, 0);
+    });
+
+    it('did not call redisClient.set', () => {
+      assert.equal(redisClient.setAsync.callCount, 0);
+    });
+
+    it('did not call redisClient.unwatch', () => {
+      assert.equal(redisClient.unwatch.callCount, 0);
+    });
+
+    it('did not call log.error', () => {
+      assert.equal(log.error.callCount, 0);
+    });
+  });
+
+  describe('redisConnection.update with falsey value:', () => {
+    beforeEach(() => {
+      return connection.update('wibble', () => {});
+    });
+
+    it('called redisClient.watch', () => {
+      assert.equal(redisClient.watchAsync.callCount, 1);
+    });
+
+    it('called redisClient.get', () => {
+      assert.equal(redisClient.getAsync.callCount, 1);
+    });
+
+    it('called redisClient.multi', () => {
+      assert.equal(redisClient.multi.callCount, 1);
+    });
+
+    it('called redisMulti.del correctly', () => {
+      assert.equal(redisMulti.del.callCount, 1);
+      const args = redisMulti.del.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'wibble');
+    });
+
+    it('called redisMulti.exec', () => {
+      assert.equal(redisMulti.execAsync.callCount, 1);
+    });
+
+    it('did not call redisMulti.set', () => {
+      assert.equal(redisMulti.set.callCount, 0);
+    });
+
+    it('did not call redisClient.set', () => {
+      assert.equal(redisClient.setAsync.callCount, 0);
+    });
+
+    it('did not call redisClient.unwatch', () => {
+      assert.equal(redisClient.unwatch.callCount, 0);
+    });
+
+    it('did not call log.error', () => {
+      assert.equal(log.error.callCount, 0);
+    });
+  });
+
+  describe('redisConnection.destroy:', () => {
+    let resolved;
+
+    beforeEach(done => {
+      connection.destroy()
+        .then(() => resolved = true);
+      setImmediate(done);
+    });
+
+    it('called redisClient.quit correctly', () => {
+      assert.equal(redisClient.quit.callCount, 1);
+      assert.lengthOf(redisClient.quit.args[0], 0);
+    });
+
+    it('called redisClient.on correctly', () => {
+      assert.equal(redisClient.on.callCount, 1);
+      const args = redisClient.on.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'end');
+      assert.isFunction(args[1]);
+    });
+
+    it('did not resolve', () => {
+      assert.isUndefined(resolved);
+    });
+
+    it('redisConnection.isValid returns false', () => {
+      assert.isFalse(connection.isValid());
+    });
+
+    describe('redisConnection.destroy:', () => {
+      let innerResolved;
+
+      beforeEach(done => {
+        connection.destroy()
+          .then(() => innerResolved = true);
+        setImmediate(done);
+      });
+
+      it('did not call redisClient.quit a second time', () => {
+        assert.equal(redisClient.quit.callCount, 1);
+      });
+
+      it('did not call redisClient.on a second time', () => {
+        assert.equal(redisClient.on.callCount, 1);
+      });
+
+      it('did not resolve', () => {
+        assert.isUndefined(innerResolved);
+      });
+
+      describe('end event handler:', () => {
+        beforeEach(done => {
+          redisClient.on.args[0][1]();
+          setImmediate(done);
+        });
+
+        it('resolved the outer promise', () => {
+          assert.isTrue(resolved);
+        });
+
+        it('resolved the inner promise', () => {
+          assert.isTrue(innerResolved);
+        });
+      });
+    });
+  });
+
+  describe('redisClient.get error:', () => {
+    beforeEach(() => {
+      redisClient.getAsync = sinon.spy(() => Promise.reject({ message: 'mock get error' }));
+    });
+
+    describe('redisConnection.get:', () => {
+      let error;
+
+      beforeEach(() => {
+        return connection.get('wibble')
+          .catch(e => error = e);
+      });
+
+      it('rejected', () => {
+        assert.deepEqual(error, { message: 'mock get error' });
+      });
+
+      it('called redisClient.get', () => {
+        assert.equal(redisClient.getAsync.callCount, 1);
+      });
+    });
+
+    describe('redisConnection.update:', () => {
+      let error;
+
+      beforeEach(() => {
+        return connection.update('wibble', getValue)
+          .catch(e => error = e);
+      });
+
+      it('rejected', () => {
+        assert.deepEqual(error, { message: 'mock get error' });
+      });
+
+      it('called redisClient.watch', () => {
+        assert.equal(redisClient.watchAsync.callCount, 1);
+      });
+
+      it('called redisClient.get', () => {
+        assert.equal(redisClient.getAsync.callCount, 1);
+      });
+
+      it('did not call getValue', () => {
+        assert.equal(getValue.callCount, 0);
+      });
+
+      it('did not call redisClient.multi', () => {
+        assert.equal(redisClient.multi.callCount, 0);
+      });
+
+      it('did not call redisMulti.set', () => {
+        assert.equal(redisMulti.set.callCount, 0);
+      });
+
+      it('did not call redisMulti.del', () => {
+        assert.equal(redisMulti.del.callCount, 0);
+      });
+
+      it('did not call redisMulti.exec', () => {
+        assert.equal(redisMulti.execAsync.callCount, 0);
+      });
+
+      it('called log.error correctly', () => {
+        assert.equal(log.error.callCount, 1);
+        const args = log.error.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'redis.update.error');
+        assert.deepEqual(args[1], { key: 'wibble', error: 'mock get error' });
+      });
+
+      it('called redisClient.unwatch correctly', () => {
+        assert.equal(redisClient.unwatch.callCount, 1);
+        assert.lengthOf(redisClient.unwatch.args[0], 0);
+      });
+    });
+  });
+
+  describe('redisClient.set error:', () => {
+    beforeEach(() => {
+      redisClient.setAsync = sinon.spy(() => Promise.reject({ message: 'mock set error' }));
+    });
+
+    describe('redisConnection.set:', () => {
+      let error;
+
+      beforeEach(() => {
+        return connection.set('wibble', 'blee')
+          .catch(e => error = e);
+      });
+
+      it('rejected', () => {
+        assert.deepEqual(error, { message: 'mock set error' });
+      });
+
+      it('called redisClient.set', () => {
+        assert.equal(redisClient.setAsync.callCount, 1);
+      });
+    });
+  });
+
+  describe('redisClient.del error:', () => {
+    beforeEach(() => {
+      redisClient.delAsync = sinon.spy(() => Promise.reject({ message: 'mock del error' }));
+    });
+
+    describe('redisConnection.set:', () => {
+      let error;
+
+      beforeEach(() => {
+        return connection.del('wibble')
+          .catch(e => error = e);
+      });
+
+      it('rejected', () => {
+        assert.deepEqual(error, { message: 'mock del error' });
+      });
+
+      it('called redisClient.del', () => {
+        assert.equal(redisClient.delAsync.callCount, 1);
+      });
+    });
+  });
+
+  describe('redisMulti.exec error:', () => {
+    beforeEach(() => {
+      redisMulti.execAsync = sinon.spy(() => Promise.reject({ message: 'mock exec error' }));
+    });
+
+    describe('redisConnection.update:', () => {
+      let error;
+
+      beforeEach(() => {
+        return connection.update('wibble', getValue)
+          .catch(e => error = e);
+      });
+
+      it('rejected', () => {
+        assert.deepEqual(error, { message: 'mock exec error' });
+      });
+
+      it('called redisClient.watch', () => {
+        assert.equal(redisClient.watchAsync.callCount, 1);
+      });
+
+      it('called redisClient.get', () => {
+        assert.equal(redisClient.getAsync.callCount, 1);
+      });
+
+      it('called getValue', () => {
+        assert.equal(getValue.callCount, 1);
+      });
+
+      it('called redisClient.multi', () => {
+        assert.equal(redisClient.multi.callCount, 1);
+      });
+
+      it('called redisMulti.set', () => {
+        assert.equal(redisMulti.set.callCount, 1);
+      });
+
+      it('called redisMulti.exec', () => {
+        assert.equal(redisMulti.execAsync.callCount, 1);
+      });
+
+      it('called redisClient.unwatch', () => {
+        assert.equal(redisClient.unwatch.callCount, 1);
+      });
+
+      it('called log.error correctly', () => {
+        assert.equal(log.error.callCount, 1);
+        const args = log.error.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'redis.update.error');
+        assert.deepEqual(args[1], { key: 'wibble', error: 'mock exec error' });
+      });
+
+      it('did not call redisMulti.del', () => {
+        assert.equal(redisMulti.del.callCount, 0);
+      });
+    });
+  });
+
+  describe('redisMulti.exec returns null:', () => {
+    beforeEach(() => {
+      redisMulti.execAsync = sinon.spy(() => Promise.resolve(null));
+    });
+
+    describe('redisConnection.update:', () => {
+      let error;
+
+      beforeEach(() => {
+        return connection.update('wibble', getValue)
+          .catch(e => error = e);
+      });
+
+      it('rejected', () => {
+        assert.instanceOf(error, Error);
+        assert.equal(error.message, 'redis.watch.conflict');
+      });
+
+      it('called redisClient.watch', () => {
+        assert.equal(redisClient.watchAsync.callCount, 1);
+      });
+
+      it('called redisClient.get', () => {
+        assert.equal(redisClient.getAsync.callCount, 1);
+      });
+
+      it('called getValue', () => {
+        assert.equal(getValue.callCount, 1);
+      });
+
+      it('called redisClient.multi', () => {
+        assert.equal(redisClient.multi.callCount, 1);
+      });
+
+      it('called redisMulti.set', () => {
+        assert.equal(redisMulti.set.callCount, 1);
+      });
+
+      it('called redisMulti.exec', () => {
+        assert.equal(redisMulti.execAsync.callCount, 1);
+      });
+
+      it('called log.warn correctly', () => {
+        assert.equal(log.error.callCount, 0);
+        assert.equal(log.warn.callCount, 1);
+        const args = log.warn.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'redis.watch.conflict');
+        assert.deepEqual(args[1], { key: 'wibble' });
+      });
+
+      it('did not call redisMulti.del', () => {
+        assert.equal(redisMulti.del.callCount, 0);
+      });
+
+      it('did not call redisClient.unwatch', () => {
+        assert.equal(redisClient.unwatch.callCount, 0);
+      });
+    });
+  });
+});

--- a/test/redis/index.js
+++ b/test/redis/index.js
@@ -1,0 +1,304 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const { assert } = require('chai');
+const Promise = require(`${ROOT_DIR}/promise`);
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+describe('redis disabled:', () => {
+  let log, pool, result;
+
+  before(() => {
+    log = {
+      error: sinon.spy(),
+      info: sinon.spy(),
+      warn: sinon.spy()
+    };
+    pool = { acquire: sinon.spy() };
+    result = proxyquire(`${ROOT_DIR}/redis`, {
+      './pool': pool
+    })({ enabled: false }, log);
+  });
+
+  it('did not call pool.acquire', () => {
+    assert.equal(pool.acquire.callCount, 0);
+  });
+
+  it('called log.info correctly', () => {
+    assert.equal(log.info.callCount, 1);
+    const args = log.info.args[0];
+    assert.lengthOf(args, 1);
+    assert.equal(args[0], 'redis.disabled');
+  });
+
+  it('returned undefined', () => {
+    assert.isUndefined(result);
+  });
+});
+
+describe('redis enabled:', () => {
+  let config, log, connection, dispose, pool, initialisePool, redis;
+
+  beforeEach(() => {
+    config = { enabled: true };
+    log = {
+      error: sinon.spy(),
+      info: sinon.spy(),
+      warn: sinon.spy()
+    };
+    connection = {
+      get: sinon.spy(() => 'mock get result'),
+      set: sinon.spy(),
+      del: sinon.spy(),
+      update: sinon.spy()
+    };
+    dispose = sinon.spy();
+    pool = { acquire: sinon.spy(() => Promise.resolve(connection).disposer(dispose)) };
+    initialisePool = sinon.spy(() => pool);
+    redis = proxyquire(`${ROOT_DIR}/redis`, { './pool': initialisePool })(config, log);
+  });
+
+  it('called log.info correctly', () => {
+    assert.equal(log.info.callCount, 1);
+    const args = log.info.args[0];
+    assert.lengthOf(args, 2);
+    assert.equal(args[0], 'redis.enabled');
+    assert.deepEqual(args[1], { config });
+  });
+
+  it('initialised pool correctly', () => {
+    assert.equal(initialisePool.callCount, 1);
+    const args = initialisePool.args[0];
+    assert.lengthOf(args, 2);
+    assert.equal(args[0], config);
+    assert.equal(args[1], log);
+  });
+
+  it('returned interface', () => {
+    assert.lengthOf(Object.keys(redis), 5);
+    assert.isFunction(redis.get);
+    assert.isFunction(redis.set);
+    assert.isFunction(redis.del);
+    assert.isFunction(redis.update);
+    assert.isFunction(redis.close);
+  });
+
+  it('did not call pool.acquire', () => {
+    assert.equal(pool.acquire.callCount, 0);
+  });
+
+  describe('redis.get:', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await redis.get('foo');
+    });
+
+    it('called pool.acquire correctly', () => {
+      assert.equal(pool.acquire.callCount, 1);
+      assert.lengthOf(pool.acquire.args[0], 0);
+    });
+
+    it('called connection.get correctly', () => {
+      assert.equal(connection.get.callCount, 1);
+      const args = connection.get.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'foo');
+    });
+
+    it('called dispose correctly', () => {
+      assert.equal(dispose.callCount, 1);
+      const args = dispose.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], connection);
+    });
+
+    it('returned the get result', () => {
+      assert.equal(result, 'mock get result');
+    });
+
+    it('did not call any other connection methods', () => {
+      assert.equal(connection.set.callCount, 0);
+      assert.equal(connection.del.callCount, 0);
+      assert.equal(connection.update.callCount, 0);
+    });
+  });
+
+  describe('redis.set:', () => {
+    beforeEach(() => {
+      return redis.set('wibble', 'blee');
+    });
+
+    it('called pool.acquire correctly', () => {
+      assert.equal(pool.acquire.callCount, 1);
+      assert.lengthOf(pool.acquire.args[0], 0);
+    });
+
+    it('called connection.set correctly', () => {
+      assert.equal(connection.set.callCount, 1);
+      const args = connection.set.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'wibble');
+      assert.equal(args[1], 'blee');
+    });
+
+    it('called dispose correctly', () => {
+      assert.equal(dispose.callCount, 1);
+      const args = dispose.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], connection);
+    });
+
+    it('did not call any other connection methods', () => {
+      assert.equal(connection.get.callCount, 0);
+      assert.equal(connection.del.callCount, 0);
+      assert.equal(connection.update.callCount, 0);
+    });
+  });
+
+  describe('redis.del:', () => {
+    beforeEach(() => {
+      return redis.del('foo');
+    });
+
+    it('called pool.acquire correctly', () => {
+      assert.equal(pool.acquire.callCount, 1);
+      assert.lengthOf(pool.acquire.args[0], 0);
+    });
+
+    it('called connection.del correctly', () => {
+      assert.equal(connection.del.callCount, 1);
+      const args = connection.del.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], 'foo');
+    });
+
+    it('called dispose correctly', () => {
+      assert.equal(dispose.callCount, 1);
+      const args = dispose.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], connection);
+    });
+
+    it('did not call any other connection methods', () => {
+      assert.equal(connection.get.callCount, 0);
+      assert.equal(connection.set.callCount, 0);
+      assert.equal(connection.update.callCount, 0);
+    });
+  });
+
+  describe('redis.update:', () => {
+    beforeEach(() => {
+      return redis.update('bar', 'baz');
+    });
+
+    it('called pool.acquire correctly', () => {
+      assert.equal(pool.acquire.callCount, 1);
+      assert.lengthOf(pool.acquire.args[0], 0);
+    });
+
+    it('called connection.update correctly', () => {
+      assert.equal(connection.update.callCount, 1);
+      const args = connection.update.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'bar');
+      assert.equal(args[1], 'baz');
+    });
+
+    it('called dispose correctly', () => {
+      assert.equal(dispose.callCount, 1);
+      const args = dispose.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], connection);
+    });
+
+    it('did not call any other connection methods', () => {
+      assert.equal(connection.get.callCount, 0);
+      assert.equal(connection.set.callCount, 0);
+      assert.equal(connection.del.callCount, 0);
+    });
+  });
+
+  describe('connection methods fail:', () => {
+    beforeEach(() => {
+      connection.get = sinon.spy(() => Promise.reject('foo'));
+      connection.set = sinon.spy(() => Promise.reject('bar'));
+      connection.del = sinon.spy(() => Promise.reject('baz'));
+      connection.update = sinon.spy(() => Promise.reject('qux'));
+    });
+
+    describe('redis.get:', () => {
+      let error;
+
+      beforeEach(() => {
+        return redis.get('wibble')
+          .catch(e => error = e);
+      });
+
+      it('called dispose', () => {
+        assert.equal(dispose.callCount, 1);
+      });
+
+      it('propagated the error', () => {
+        assert.equal(error, 'foo');
+      });
+    });
+
+    describe('redis.set:', () => {
+      let error;
+
+      beforeEach(() => {
+        return redis.set('wibble', 'blee')
+          .catch(e => error = e);
+      });
+
+      it('called dispose', () => {
+        assert.equal(dispose.callCount, 1);
+      });
+
+      it('propagated the error', () => {
+        assert.equal(error, 'bar');
+      });
+    });
+
+    describe('redis.del:', () => {
+      let error;
+
+      beforeEach(() => {
+        return redis.del('wibble')
+          .catch(e => error = e);
+      });
+
+      it('called dispose', () => {
+        assert.equal(dispose.callCount, 1);
+      });
+
+      it('propagated the error', () => {
+        assert.equal(error, 'baz');
+      });
+    });
+
+    describe('redis.update:', () => {
+      let error;
+
+      beforeEach(() => {
+        return redis.update('wibble', 'blee')
+          .catch(e => error = e);
+      });
+
+      it('called dispose', () => {
+        assert.equal(dispose.callCount, 1);
+      });
+
+      it('propagated the error', () => {
+        assert.equal(error, 'qux');
+      });
+    });
+  });
+});

--- a/test/redis/integration.js
+++ b/test/redis/integration.js
@@ -1,0 +1,242 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const { assert } = require('chai');
+const Promise = require(`${ROOT_DIR}/promise`);
+
+describe('redis integration:', () => {
+  let config, log, redis;
+
+  before(() => {
+    config = {
+      enabled: true,
+      host: process.env.REDIS_HOST || '127.0.0.1',
+      port: process.env.REDIS_PORT || 6379,
+      prefix: process.env.REDIS_PREFIX || 'fxa-shared-test:',
+      maxConnections: process.env.REDIS_POOL_MAX_CONNECTIONS || 200,
+      minConnections: process.env.REDIS_POOL_MIN_CONNECTIONS || 2
+    };
+    log = { info () {}, warn () {}, error () {} };
+    redis = require(`${ROOT_DIR}/redis`)(config, log);
+  });
+
+  after(() => redis.close());
+
+  describe('set:', () => {
+    before(() => {
+      return redis.set('foo', 'bar');
+    });
+
+    it('get reads data', async () => {
+      const results = await Promise.all([ redis.get('foo'), redis.get('foo') ]);
+      results.forEach(result => assert.equal(result, 'bar'));
+    });
+  });
+
+  describe('concurrent sets:', () => {
+    before(() => {
+      return Promise.all([ redis.set('foo', '1'), redis.set('foo', '2') ]);
+    });
+
+    it('data was set', async () => {
+      assert.match(await redis.get('foo'), /^(?:1|2)$/);
+    });
+  });
+
+  describe('del:', () => {
+    before(() => {
+      return redis.del('foo');
+    });
+
+    it('data was deleted', async () => {
+      assert.isNull(await redis.get('foo'));
+    });
+  });
+
+  describe('update:', () => {
+    before(async () => {
+      await redis.set('foo', 'bar');
+      await redis.update('foo', oldValue => `${oldValue}2`);
+    });
+
+    it('data was set', async () => {
+      assert.equal(await redis.get('foo'), 'bar2');
+    });
+  });
+
+  describe('update non-existent key:', () => {
+    before(async () => {
+      await redis.del('wibble');
+      await redis.update('wibble', () => 'blee');
+    });
+
+    it('data was set', async () => {
+      assert.equal(await redis.get('wibble'), 'blee');
+    });
+  });
+
+  describe('update existing key to falsey value:', () => {
+    before(() => {
+      return redis.update('wibble', () => '');
+    });
+
+    it('data was deleted', async () => {
+      assert.isNull(await redis.get('wibble'));
+    });
+  });
+
+  describe('concurrent updates of the same key:', () => {
+    const errors = [];
+    let winner;
+
+    before(() => {
+      let resolve, sum = 0;
+      const synchronisationPromise = new Promise(r => resolve = r);
+
+      return Promise.all([ 1, 2 ].map(async value => {
+        try {
+          await redis.update('foo', createUpdateHandler(value));
+          winner = value;
+        } catch (error) {
+          errors.push(error);
+        }
+      }));
+
+      function createUpdateHandler (value) {
+        return async () => {
+          sum += value;
+          if (sum === 3) {
+            resolve();
+          }
+          await synchronisationPromise;
+          return value;
+        };
+      }
+    });
+
+    it('one update failed', () => {
+      assert.lengthOf(errors, 1);
+      assert.equal(errors[0].message, 'redis.watch.conflict');
+    });
+
+    it('the other update completed successfully', async () => {
+      assert.equal(await redis.get('foo'), winner);
+    });
+  });
+
+  describe('concurrent updates of different keys:', () => {
+    before(() => {
+      let resolve, values = '';
+      const synchronisationPromise = new Promise(r => resolve = r);
+
+      return Promise.all([
+        redis.update('foo', createUpdateHandler('bar')),
+        redis.update('baz', createUpdateHandler('qux'))
+      ]);
+
+      function createUpdateHandler (value) {
+        return async () => {
+          values += value;
+          if (values.length === 6) {
+            resolve();
+          }
+          await synchronisationPromise;
+          return value;
+        };
+      }
+    });
+
+    it('first update completed successfully', async () => {
+      assert.equal(await redis.get('foo'), 'bar');
+    });
+
+    it('second update completed successfully', async () => {
+      assert.equal(await redis.get('baz'), 'qux');
+    });
+  });
+
+  describe('reentrant updates of different keys:', () => {
+    let redisPool, error;
+
+    before(() => {
+      redisPool = require(`${ROOT_DIR}/redis/pool`)(config, log);
+      return Promise.using(
+        redisPool.acquire(),
+        connection => connection.update('foo', async oldFoo => {
+          try {
+            await connection.update('baz', oldBaz => `${oldBaz}2`);
+          } catch (e) {
+            error = e;
+          }
+          return `${oldFoo}2`;
+        })
+      );
+    });
+
+    after(() => redisPool.close());
+
+    it('first update completed successfully', async () => {
+      assert.equal(await redis.get('foo'), 'bar2');
+    });
+
+    it('second update failed', async () => {
+      assert.ok(error);
+      assert.equal(error.message, 'redis.update.conflict');
+      assert.equal(await redis.get('baz'), 'qux');
+    });
+  });
+
+  describe('set concurrently with update:', () => {
+    let error;
+
+    before(async () => {
+      try {
+        await redis.update('foo', async () => {
+          await redis.set('foo', 'blee');
+          return 'wibble';
+        });
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    it('update failed', () => {
+      assert.ok(error);
+      assert.equal(error.message, 'redis.watch.conflict');
+    });
+
+    it('data was set', async () => {
+      assert.equal(await redis.get('foo'), 'blee');
+    });
+  });
+
+  describe('del concurrently with update:', () => {
+    let error;
+
+    before(async () => {
+      try {
+        await redis.set('foo', 'bar');
+        await redis.update('foo', async () => {
+          await redis.del('foo');
+          return 'baz';
+        });
+      } catch (e) {
+        error = e;
+      }
+    });
+
+    it('update failed', () => {
+      assert.ok(error);
+      assert.equal(error.message, 'redis.watch.conflict');
+    });
+
+    it('data was deleted', async () => {
+      assert.isNull(await redis.get('foo'));
+    });
+  });
+});

--- a/test/redis/pool.js
+++ b/test/redis/pool.js
@@ -1,0 +1,253 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const { assert } = require('chai');
+const Promise = require(`${ROOT_DIR}/promise`);
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+describe('redis/pool:', () => {
+  let log, redis, redisCreateClient, redisConnection, connection, genericPool, genericPoolCreatePool, redisPool;
+
+  beforeEach(() => {
+    log = {
+      error: sinon.spy(),
+      info: sinon.spy(),
+      warn: sinon.spy()
+    };
+    redis = {
+      on: sinon.spy()
+    };
+    redisCreateClient = sinon.spy(() => redis);
+    connection = {
+      isValid: sinon.spy(() => 'mock isValid result'),
+      destroy: sinon.spy(() => 'mock destroy result')
+    };
+    redisConnection = sinon.spy(() => connection);
+    genericPool = {
+      on: sinon.spy(),
+      acquire: sinon.spy(() => Promise.resolve(connection)),
+      release: sinon.spy()
+    };
+    genericPoolCreatePool = sinon.spy(() => genericPool);
+    redisPool = proxyquire(`${ROOT_DIR}/redis/pool`, {
+      'generic-pool': { createPool: genericPoolCreatePool },
+      redis: { createClient: redisCreateClient },
+      './connection': redisConnection
+    })({
+      host: 'foo',
+      port: 'bar',
+      prefix: 'baz',
+      retryCount: 3,
+      initialBackoff: 100,
+      maxConnections: 'qux',
+      minConnections: 'wibble',
+      maxPending: 'blee'
+    }, log);
+  });
+
+  it('called genericPool.createPool correctly', () => {
+    assert.equal(genericPoolCreatePool.callCount, 1);
+    const args = genericPoolCreatePool.args[0];
+    assert.lengthOf(args, 2);
+    assert.isFunction(args[0].create);
+    assert.isFunction(args[0].destroy);
+    assert.isFunction(args[0].validate);
+    // Can't deepEqual args[1] because of Promise
+    assert.equal(args[1].acquireTimeoutMillis, 700);
+    assert.isTrue(args[1].autostart);
+    assert.equal(args[1].max, 'qux');
+    assert.equal(args[1].maxWaitingClients, 'blee');
+    assert.equal(args[1].min, 'wibble');
+    assert.equal(args[1].Promise, Promise);
+    assert.equal(args[1].testOnBorrow, true);
+  });
+
+  it('called pool.on correctly', () => {
+    assert.equal(genericPool.on.callCount, 1);
+    const args = genericPool.on.args[0];
+    assert.lengthOf(args, 2);
+    assert.equal(args[0], 'factoryCreateError');
+    assert.isFunction(args[1]);
+  });
+
+  it('returned pool object', () => {
+    assert.lengthOf(Object.keys(redisPool), 2);
+    assert.isFunction(redisPool.acquire);
+    assert.isFunction(redisPool.close);
+  });
+
+  it('did not call connection.isValid', () => {
+    assert.equal(connection.isValid.callCount, 0);
+  });
+
+  it('did not call connection.destroy', () => {
+    assert.equal(connection.destroy.callCount, 0);
+  });
+
+  it('did not call pool.acquire', () => {
+    assert.equal(genericPool.acquire.callCount, 0);
+  });
+
+  describe('redisFactory.create:', () => {
+    let result;
+
+    beforeEach(done => {
+      genericPoolCreatePool.args[0][0].create()
+        .then(r => result = r);
+      setImmediate(done);
+    });
+
+    it('called redis.createClient correctly', () => {
+      assert.equal(redisCreateClient.callCount, 1);
+      const args = redisCreateClient.args[0];
+      assert.lengthOf(args, 1);
+      assert.lengthOf(Object.keys(args[0]), 5);
+      assert.equal(args[0].host, 'foo');
+      assert.equal(args[0].port, 'bar');
+      assert.equal(args[0].prefix, 'baz');
+      assert.equal(args[0].enable_offline_queue, false);
+      assert.isFunction(args[0].retry_strategy);
+    });
+
+    it('called redisClient.on correctly', () => {
+      assert.equal(redis.on.callCount, 2);
+
+      let args = redis.on.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'ready');
+      assert.isFunction(args[1]);
+
+      args = redis.on.args[1];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'error');
+      assert.isFunction(args[1]);
+    });
+
+    it('did not resolve', () => {
+      assert.isUndefined(result);
+    });
+
+    it('did not call redisConnection', () => {
+      assert.equal(redisConnection.callCount, 0);
+    });
+
+    describe('redis ready event:', () => {
+      beforeEach(done => {
+        redis.on.args[0][1]();
+        setImmediate(done);
+      });
+
+      it('called redisConnection correctly', () => {
+        assert.equal(redisConnection.callCount, 1);
+        const args = redisConnection.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], log);
+        assert.equal(args[1], redis);
+      });
+
+      it('resolved the redisFactory.create promise', () => {
+        assert.equal(result, connection);
+      });
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0);
+      });
+    });
+
+    describe('redis error event:', () => {
+      beforeEach(() => redis.on.args[1][1]({ message: 'foo' }));
+
+      it('should log the error', () => {
+        assert.equal(log.error.callCount, 1);
+        const args = log.error.args[0];
+        assert.lengthOf(args, 2);
+        assert.equal(args[0], 'redis.error');
+        assert.deepEqual(args[1], { error: 'foo' });
+      });
+    });
+  });
+
+  describe('redisFactory.validate:', () => {
+    let result;
+
+    beforeEach(() => {
+      result = genericPoolCreatePool.args[0][0].validate(connection);
+    });
+
+    it('called connection.isValid correctly', () => {
+      assert.equal(connection.isValid.callCount, 1);
+      assert.lengthOf(connection.isValid.args[0], 0);
+    });
+
+    it('returned the isValid result', () => {
+      assert.equal(result, 'mock isValid result');
+    });
+  });
+
+  describe('redisFactory.destroy:', () => {
+    let result;
+
+    beforeEach(() => {
+      result = genericPoolCreatePool.args[0][0].destroy(connection);
+    });
+
+    it('called connection.destroy correctly', () => {
+      assert.equal(connection.destroy.callCount, 1);
+      assert.lengthOf(connection.destroy.args[0], 0);
+    });
+
+    it('returned the destroy result', () => {
+      assert.equal(result, 'mock destroy result');
+    });
+  });
+
+  describe('factoryCreateError event handler:', () => {
+    beforeEach(() => {
+      genericPool.on.args[0][1]({ message: 'mock factory create error' });
+    });
+
+    it('called log.error correctly', () => {
+      assert.equal(log.error.callCount, 1);
+      const args = log.error.args[0];
+      assert.lengthOf(args, 2);
+      assert.deepEqual(args[0], 'redisFactory.error');
+      assert.deepEqual(args[1], { error: 'mock factory create error' });
+    });
+  });
+
+  describe('redisPool.acquire:', () => {
+    let result;
+
+    beforeEach(() => {
+      result = redisPool.acquire();
+    });
+
+    it('called pool.acquire correctly', () => {
+      assert.equal(genericPool.acquire.callCount, 1);
+      assert.lengthOf(genericPool.acquire.args[0], 0);
+    });
+
+    it('did not return a promise', () => {
+      assert.isUndefined(result.then);
+    });
+
+    it('did not call pool.release', () => {
+      assert.equal(genericPool.release.callCount, 0);
+    });
+
+    it('returned a disposer for the connection', async () => {
+      await Promise.using(result, r => assert.equal(r, connection));
+
+      assert.equal(genericPool.release.callCount, 1);
+      const args = genericPool.release.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], connection);
+    });
+  });
+});


### PR DESCRIPTION
As a pre-requisite for feature-flagging, this PR pulls the Redis abstraction out of the auth server so we can use it in the content server too.

The abstraction originates from mozilla/fxa-auth-server#2235 and a fair amount of discussion took place in that PR so if you have any questions about why things are done in a certain way, it might be worth having a read of that first. In particular, the error semantics of the node Redis client are kind of flaky and what's here is our battle-hardened approach to working sanely under those conditions.

The implementation depends on bluebird promises, although I know some on the team think we should be moving away from bluebird rather than towards it. In my defence, bluebird's disposer pattern is really handy for robustly managing connections and I'm not enthusiastic about re-implementing it from scratch here. I'd probably get it wrong, plus it heaps further testing and maintenance burden on us.

Note that the tests will now fail for anyone who doesn't have Redis installed, because there are some integration tests that require a real instance to run against. That might seem slightly odd because our config for connecting to Redis doesn't live in this repo, it is of course server-specific. I could have left the integration tests in the server repos alongside the config, but that would incur a lengthy interval between bugs being introduced here and then picked up during integration.

@mozilla/fxa-devs r?