### PR TITLE
feat(redis): add methods for managing sorted sets

### DIFF
--- a/redis/connection.js
+++ b/redis/connection.js
@@ -6,87 +6,92 @@
 
 const Promise = require('../promise');
 
-module.exports = (log, client) => {
-  let isUpdating = false;
-  let destroyPromise;
+// Redis command reference: https://redis.io/commands
+const SUPPORTED_COMMANDS = [
+  // Basic operations
+  'get', 'set', 'del',
+  // Sorted sets: https://redis.io/topics/data-types-intro#redis-sorted-sets
+  'zadd', 'zrange', 'zrangebyscore', 'zrem', 'zremrangebyscore', 'zrevrange', 'zrevrangebyscore'
+];
 
-  return {
-    get (key) {
-      return client.getAsync(key);
-    },
+module.exports = {
+  methods: SUPPORTED_COMMANDS.concat('update'),
 
-    set (key, value) {
-      return client.setAsync(key, value);
-    },
+  create (log, client) {
+    let isUpdating = false;
+    let destroyPromise;
 
-    del (key) {
-      return client.delAsync(key);
-    },
+    return {
+      ...SUPPORTED_COMMANDS.reduce((object, command) => {
+        object[command] = (...args) => client[`${command}Async`](...args);
+        return object;
+      }, {}),
 
-    /**
-     * To ensure safe update semantics in the presence of concurrency,
-     * we lean on Redis' WATCH, MULTI and EXEC commands so that updates
-     * run as a transaction and will fail if the data changes underneath
-     * them. You can read more about this in the Redis docs:
-     *
-     *   https://redis.io/topics/transactions
-     *
-     * @param key {String} The key to update
-     * @param getUpdatedValue {Function} A callback that receives the current value
-     *                                   and returns the updated value. May return a
-     *                                   promise or the raw updated value.
-     */
-    async update (key, getUpdatedValue) {
-      if (isUpdating) {
-        log.error('redis.update.conflict', { key });
-        throw new Error('redis.update.conflict');
-      }
-
-      let result;
-      isUpdating = true;
-
-      try {
-        await client.watchAsync(key);
-
-        const value = await getUpdatedValue(await client.getAsync(key));
-        const multi = client.multi();
-
-        if (value) {
-          multi.set(key, value);
-        } else {
-          multi.del(key);
+      /**
+       * To ensure safe update semantics in the presence of concurrency,
+       * we lean on Redis' WATCH, MULTI and EXEC commands so that updates
+       * run as a transaction and will fail if the data changes underneath
+       * them. You can read more about this in the Redis docs:
+       *
+       *   https://redis.io/topics/transactions
+       *
+       * @param key {String} The key to update
+       * @param getUpdatedValue {Function} A callback that receives the current value
+       *                                   and returns the updated value. May return a
+       *                                   promise or the raw updated value.
+       */
+      async update (key, getUpdatedValue) {
+        if (isUpdating) {
+          log.error('redis.update.conflict', { key });
+          throw new Error('redis.update.conflict');
         }
 
-        result = await multi.execAsync();
-      } catch (error) {
-        client.unwatch();
-        log.error('redis.update.error', { key, error: error.message });
+        let result;
+        isUpdating = true;
+
+        try {
+          await client.watchAsync(key);
+
+          const value = await getUpdatedValue(await client.getAsync(key));
+          const multi = client.multi();
+
+          if (value) {
+            multi.set(key, value);
+          } else {
+            multi.del(key);
+          }
+
+          result = await multi.execAsync();
+        } catch (error) {
+          client.unwatch();
+          log.error('redis.update.error', { key, error: error.message });
+          isUpdating = false;
+          throw error;
+        }
+
         isUpdating = false;
-        throw error;
+        if (! result) {
+          // Really this isn't an error as such, it just indicates that
+          // this function is operating sanely in concurrent conditions.
+          log.warn('redis.watch.conflict', { key });
+          throw new Error('redis.watch.conflict');
+        }
+      },
+
+      destroy () {
+        if (! destroyPromise) {
+          destroyPromise = new Promise(resolve => {
+            client.quit();
+            client.on('end', resolve);
+          });
+        }
+
+        return destroyPromise;
+      },
+
+      isValid () {
+        return ! destroyPromise;
       }
-
-      isUpdating = false;
-      if (! result) {
-        // Really this isn't an error as such, it just indicates that
-        // this function is operating sanely in concurrent conditions.
-        log.warn('redis.watch.conflict', { key });
-        throw new Error('redis.watch.conflict');
-      }
-    },
-
-    destroy () {
-      if (! destroyPromise) {
-        destroyPromise = new Promise(resolve => {
-          client.quit();
-          client.on('end', resolve);
-        });
-      }
-
-      return destroyPromise;
-    },
-
-    isValid () {
-      return ! destroyPromise;
-    }
-  };
+    };
+  },
 };

--- a/redis/index.js
+++ b/redis/index.js
@@ -8,7 +8,7 @@
 // occurred". You do not need to worry about acquiring or releasing connections
 // yourself.
 //
-// Usage:
+// Basic usage:
 //
 //   const redis = require('fxa-shared/redis');
 //
@@ -43,12 +43,15 @@
 //     .catch(error => {
 //       // :(
 //     });
+//
+// Also exports many of the methods required
+// for handling sorted sets:
+//
+// zadd, zrange, zrangebyscore, zrem, zremrangebyscore, zrevrange, zrevrangebyscore
 
 'use strict';
 
 const Promise = require('../promise');
-
-const REDIS_COMMANDS = [ 'get', 'set', 'del', 'update' ];
 
 module.exports = (config, log) => {
   if (! config.enabled) {
@@ -58,9 +61,9 @@ module.exports = (config, log) => {
 
   log.info('redis.enabled', { config });
 
-  const pool = require('./pool')(config, log);
+  const { methods, pool } = require('./pool')(config, log);
 
-  return REDIS_COMMANDS.reduce((result, command) => {
+  return methods.reduce((result, command) => {
     result[command] = (...args) => Promise.using(pool.acquire(), connection => connection[command](...args));
     return result;
   }, {

--- a/redis/pool.js
+++ b/redis/pool.js
@@ -44,7 +44,7 @@ module.exports = (config, log) => {
 
         client.on('ready', () => {
           if (! connection) {
-            connection = redisConnection(log, client);
+            connection = redisConnection.create(log, client);
             resolve(connection);
           }
         });
@@ -83,20 +83,24 @@ module.exports = (config, log) => {
   pool.on('factoryCreateError', error => log.error('redisFactory.error', { error: error.message }));
 
   return {
-    /**
-     * Acquire a single-use Redis connection. Must be consumed via Promise.using().
-     *
-     * @return {Disposer} A bluebird disposer object
-     */
-    acquire () {
-      return pool.acquire().disposer(connection => pool.release(connection));
-    },
+    methods: redisConnection.methods,
 
-    /**
-     * Close the pool, releasing any network connections.
-     */
-    close () {
-      return pool.drain().then(() => pool.clear());
-    }
+    pool: {
+      /**
+       * Acquire a single-use Redis connection. Must be consumed via Promise.using().
+       *
+       * @return {Disposer} A bluebird disposer object
+       */
+      acquire () {
+        return pool.acquire().disposer(connection => pool.release(connection));
+      },
+
+      /**
+       * Close the pool, releasing any network connections.
+       */
+      close () {
+        return pool.drain().then(() => pool.clear());
+      },
+    },
   };
 };

--- a/test/redis/index.js
+++ b/test/redis/index.js
@@ -22,7 +22,12 @@ describe('redis disabled:', () => {
     };
     pool = { acquire: sinon.spy() };
     result = proxyquire(`${ROOT_DIR}/redis`, {
-      './pool': pool
+      './pool': {
+        methods: [ 'get', 'set', 'del', 'update' ],
+        pool: {
+          acquire: sinon.spy(),
+        },
+      },
     })({ enabled: false }, log);
   });
 
@@ -60,7 +65,10 @@ describe('redis enabled:', () => {
     };
     dispose = sinon.spy();
     pool = { acquire: sinon.spy(() => Promise.resolve(connection).disposer(dispose)) };
-    initialisePool = sinon.spy(() => pool);
+    initialisePool = sinon.spy(() => ({
+      methods: [ 'get', 'set', 'del', 'update' ],
+      pool,
+    }));
     redis = proxyquire(`${ROOT_DIR}/redis`, { './pool': initialisePool })(config, log);
   });
 


### PR DESCRIPTION
Blocks mozilla/fxa-auth-server#2939.

We want to use [Redis sorted sets](https://redis.io/topics/data-types-intro#redis-sorted-sets) to store verification reminders. This PR just exposes a bunch of their methods.

I think I'll probably only need `zadd`, `zrangebyscore` and `zremrangebyscore` to implement verification reminders, but I exposed a bunch of others too because it didn't require any additional code to do so and I might find uses for them when I actually do that work.

There have been some indentation changes where I expose the method names as a property, so you'll probably want to review this with [`?w=1`](https://github.com/mozilla/fxa-shared/pull/65/files?w=1).

@mozilla/fxa-devs r?