### PR TITLE
fix(redis): fix broken zpoprangebyscore argument-marshalling

### DIFF
--- a/redis/connection.js
+++ b/redis/connection.js
@@ -93,13 +93,18 @@ module.exports = {
        * @param key {String} The key for the sorted set
        * @param min {Number} The minimum score to include in the popped range.
        * @param max {Number} The maximum score to include in the popped range.
+       * @param [withScores] {Boolean} Whether to include scores in the popped ranges.
        * @returns {Promise} Resolves to the popped range.
        */
-      async zpoprangebyscore (key, min, max, ...options) {
+      async zpoprangebyscore (key, min, max, withScores) {
         const multi = client.multi();
 
-        multi.zrangebyscore(key, min, max, ...options);
-        multi.zremrangebyscore(key, min, max, ...options);
+        const args = [ key, min, max ];
+        if (withScores) {
+          args.push('WITHSCORES');
+        }
+        multi.zrangebyscore(...args);
+        multi.zremrangebyscore(key, min, max);
 
         const results = await multi.execAsync();
         return results[0];

--- a/test/redis/connection.js
+++ b/test/redis/connection.js
@@ -170,7 +170,7 @@ describe('redis/connection:', () => {
 
     beforeEach(async () => {
       redisMulti.execAsync = sinon.spy(() => Promise.resolve([ [ 'foo' ], 1 ]));
-      result = await connection.zpoprangebyscore('blee', 0, 1, 'WITHSCORES', 'LIMIT', 0, 10);
+      result = await connection.zpoprangebyscore('blee', 0, 1, true);
     });
 
     it('returned the correct result', () => {
@@ -185,27 +185,20 @@ describe('redis/connection:', () => {
     it('called redisMulti.zrangebyscore correctly', () => {
       assert.equal(redisMulti.zrangebyscore.callCount, 1);
       const args = redisMulti.zrangebyscore.args[0];
-      assert.lengthOf(args, 7);
+      assert.lengthOf(args, 4);
       assert.equal(args[0], 'blee');
       assert.equal(args[1], 0);
       assert.equal(args[2], 1);
       assert.equal(args[3], 'WITHSCORES');
-      assert.equal(args[4], 'LIMIT');
-      assert.equal(args[5], 0);
-      assert.equal(args[6], 10);
     });
 
     it('called redisMulti.zremrangebyscore correctly', () => {
       assert.equal(redisMulti.zremrangebyscore.callCount, 1);
       const args = redisMulti.zremrangebyscore.args[0];
-      assert.lengthOf(args, 7);
+      assert.lengthOf(args, 3);
       assert.equal(args[0], 'blee');
       assert.equal(args[1], 0);
       assert.equal(args[2], 1);
-      assert.equal(args[3], 'WITHSCORES');
-      assert.equal(args[4], 'LIMIT');
-      assert.equal(args[5], 0);
-      assert.equal(args[6], 10);
     });
 
     it('called redisMulti.exec correctly', () => {


### PR DESCRIPTION
Blocks mozilla/fxa-auth-server#2990.

My logic for passing through the optional arguments to `zrangebyscore`, added this morning in #67, turned out to be the cause of a frustrating bug that was causing my tests to fail this afternoon. It's obvious in hindsight, but passing the same options to `zremrangebyscore` was a foolish idea.

However it's not simply enough to just stop passing `...options` to `zremrangebyscore`, because that would allow `zrangebyscore` to return a different result set with the `offset` and `count` optional params. Instead I've simplified the interface and just pass `WITHSCORES` explicitly if specified now, which is all that's needed for the verification reminders script to work.

@mozilla/fxa-devs r?